### PR TITLE
Add ProofShot logo and banner branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# ProofShot
+<p align="center">
+  <img src="brand-assets/banners/proofshot-banner.svg" alt="ProofShot — Visual verification for AI coding agents" width="100%" />
+</p>
 
-**The open-source, agent-agnostic CLI that gives AI coding agents eyes.**
+<p align="center">
+  <strong>The open-source, agent-agnostic CLI that gives AI coding agents eyes.</strong>
+</p>
 
 Your agent builds a feature — ProofShot records video proof it works. Three commands. Any agent. Real browser verification.
 

--- a/brand-assets/banners/proofshot-banner.svg
+++ b/brand-assets/banners/proofshot-banner.svg
@@ -1,0 +1,73 @@
+<svg viewBox="0 0 1200 400" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg4" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="100%" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="mark4" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#22D3EE"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="400" fill="url(#bg4)"/>
+
+  <!-- Large decorative viewfinder — oversized, cropped at edges -->
+  <g opacity="0.06" stroke="white" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M-40,200 L-40,20 C-40,0 -20,-20 0,-20 L180,-20"/>
+    <path d="M1020,-20 L1200,-20 C1220,-20 1240,0 1240,20 L1240,200"/>
+    <path d="M-40,200 L-40,380 C-40,400 -20,420 0,420 L180,420"/>
+    <path d="M1020,420 L1200,420 C1220,420 1240,400 1240,380 L1240,200"/>
+  </g>
+
+  <!-- Center content -->
+  <!-- Viewfinder icon — gradient -->
+  <g transform="translate(366, 60)">
+    <path d="M0,36 L0,10 C0,4 4,0 10,0 L36,0" fill="none" stroke="url(#mark4)" stroke-width="5" stroke-linecap="round"/>
+    <path d="M64,0 L90,0 C96,0 100,4 100,10 L100,36" fill="none" stroke="url(#mark4)" stroke-width="5" stroke-linecap="round"/>
+    <path d="M0,64 L0,90 C0,96 4,100 10,100 L36,100" fill="none" stroke="url(#mark4)" stroke-width="5" stroke-linecap="round"/>
+    <path d="M64,100 L90,100 C96,100 100,96 100,90 L100,64" fill="none" stroke="url(#mark4)" stroke-width="5" stroke-linecap="round"/>
+    <path d="M30,56 L42,68 L72,32" fill="none" stroke="#22D3EE" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="490" y="130" font-family="Inter, SF Pro Display, -apple-system, sans-serif" font-size="56" font-weight="800" fill="white" letter-spacing="-1">ProofShot</text>
+
+  <!-- Hero tagline — large and punchy -->
+  <text x="600" y="220" text-anchor="middle" font-family="Inter, SF Pro Display, -apple-system, sans-serif" font-size="28" font-weight="300" fill="#CBD5E1">Your agent codes it.</text>
+  <text x="600" y="260" text-anchor="middle" font-family="Inter, SF Pro Display, -apple-system, sans-serif" font-size="28" font-weight="600" fill="white">ProofShot proves it works.</text>
+
+  <!-- Feature bar at bottom — 4 items evenly spaced across 800px pill (x=200..1000), centers at 320, 480, 720, 880 with separators at 400, 600, 800 -->
+  <g transform="translate(0, 310)">
+    <rect x="200" y="0" width="800" height="60" rx="30" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
+
+    <g font-family="Inter, -apple-system, sans-serif" font-size="14">
+      <!-- 4 items evenly spaced: pill is 200–1000, divide into 5 slots of 160px → centers at 360, 520, 680, 840 -->
+      <!-- Video Recording -->
+      <text x="360" y="22" text-anchor="middle" fill="#6366F1" font-weight="600" font-size="18">&#x25B6;</text>
+      <text x="360" y="44" text-anchor="middle" fill="#94A3B8">Video Recording</text>
+
+      <!-- Separator at midpoint 440 -->
+      <circle cx="440" cy="30" r="2" fill="#334155"/>
+
+      <!-- Screenshots -->
+      <text x="520" y="22" text-anchor="middle" fill="#22D3EE" font-weight="600" font-size="18">&#x25A3;</text>
+      <text x="520" y="44" text-anchor="middle" fill="#94A3B8">Screenshots</text>
+
+      <!-- Separator at midpoint 600 -->
+      <circle cx="600" cy="30" r="2" fill="#334155"/>
+
+      <!-- Error Reports -->
+      <text x="680" y="22" text-anchor="middle" fill="#F87171" font-weight="600" font-size="18">&#x26A0;</text>
+      <text x="680" y="44" text-anchor="middle" fill="#94A3B8">Error Reports</text>
+
+      <!-- Separator at midpoint 760 -->
+      <circle cx="760" cy="30" r="2" fill="#334155"/>
+
+      <!-- Interactive Viewer -->
+      <text x="840" y="22" text-anchor="middle" fill="#A78BFA" font-weight="600" font-size="18">&#x29C9;</text>
+      <text x="840" y="44" text-anchor="middle" fill="#94A3B8">Interactive Viewer</text>
+    </g>
+  </g>
+</svg>

--- a/brand-assets/svg/proofshot-mark.svg
+++ b/brand-assets/svg/proofshot-mark.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Top-left bracket -->
+  <path d="M8,24 L8,12 C8,8 12,8 12,8 L24,8" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Top-right bracket -->
+  <path d="M40,8 L52,8 C56,8 56,12 56,12 L56,24" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Bottom-left bracket -->
+  <path d="M8,40 L8,52 C8,56 12,56 12,56 L24,56" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Bottom-right bracket -->
+  <path d="M40,56 L52,56 C56,56 56,52 56,52 L56,40" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Checkmark -->
+  <path d="M20,34 L28,42 L44,22" fill="none" stroke="#22D3EE" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/artifacts/viewer.ts
+++ b/src/artifacts/viewer.ts
@@ -348,7 +348,7 @@ export function generateViewer(data: ViewerData): string {
 </head>
 <body>
   <div class="header">
-    <h1>ProofShot Verification</h1>
+    <h1><svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" style="width:24px;height:24px;vertical-align:middle;margin-right:8px"><path d="M8,24 L8,12 C8,8 12,8 12,8 L24,8" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/><path d="M40,8 L52,8 C56,8 56,12 56,12 L56,24" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/><path d="M8,40 L8,52 C8,56 12,56 12,56 L24,56" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/><path d="M40,56 L52,56 C56,56 56,52 56,52 L56,40" fill="none" stroke="#6366F1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/><path d="M20,34 L28,42 L44,22" fill="none" stroke="#22D3EE" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/></svg>ProofShot Verification</h1>
     ${descriptionHtml}
     <p class="meta">${escapeHtml(date)} &middot; ${escapeHtml(data.framework)} &middot; ${data.durationSec}s</p>
     <div class="error-badges">


### PR DESCRIPTION
## Summary

Added professional logo and hero banner branding to ProofShot. The logo features a camera viewfinder with a checkmark — combining "capture" and "verification proof," which is the core product value. The banner introduces ProofShot's purpose and key features in a visually striking design suitable for GitHub README and marketing materials.

## Changes

- **Logo mark** (`brand-assets/svg/proofshot-mark.svg`): Viewfinder + checkmark in indigo (#6366F1) and cyan (#22D3EE). Used inline in viewer.html header and as favicon template.
- **Hero banner** (`brand-assets/banners/proofshot-banner.svg`): 1200x400px minimal-bold design with centered wordmark, tagline, and feature pills (Video, Screenshots, Errors, Interactive Viewer). Integrated into README.md header.
- **README update**: Replaced plain text header with full-width banner for maximum impact on first GitHub visit.
- **Viewer enhancement**: Added inline logo to interactive verification viewer header for consistent branding.

## Design Details

Four banner concepts were explored (dark terminal, gradient hero, split workflow, minimal bold). The minimal-bold design was selected for its punchy, developer-friendly aesthetic. Features are evenly spaced at 160px intervals for perfect visual alignment.

Color palette: Indigo primary (#6366F1), Cyan accent (#22D3EE), Dark backgrounds (#0F172A, #020617), appropriate for dev tool audience.