### PR TITLE
Add user-level skill installation with proofshot install command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ npm run dev            # Watch mode build
 ```
 src/
 ├── cli.ts                  # Commander.js command registration
-├── commands/               # One file per CLI command (start, stop, exec, init, diff, pr, clean)
+├── commands/               # One file per CLI command (install, start, stop, exec, diff, pr, clean)
 ├── browser/                # agent-browser CLI wrappers (session, capture, interact, navigate)
 ├── server/                 # Dev server detection, startup, port waiting
 ├── session/state.ts        # .session.json lifecycle (save/load/clear)

--- a/README.md
+++ b/README.md
@@ -22,18 +22,10 @@ The human gets: a video recording showing what was tested, screenshots of key mo
 
 ```bash
 npm install -g proofshot
+proofshot install
 ```
 
-This also installs `agent-browser` and downloads a headless Chromium.
-
-## Setup (10 seconds)
-
-```bash
-cd your-project
-proofshot init
-```
-
-This creates a config file and installs a skill file that teaches your AI agent the verification workflow.
+The first command installs the CLI and `agent-browser` (with headless Chromium). The second detects your AI coding tools (Claude Code, Cursor, Codex, Gemini CLI, Windsurf) and installs the ProofShot skill at the user level — so it works across all your projects automatically.
 
 ## How It Works
 
@@ -60,14 +52,15 @@ The skill file teaches the agent this workflow automatically. The user just says
 
 ## Commands
 
-### `proofshot init`
+### `proofshot install`
 
-Creates config and installs skill file.
+Detects AI coding tools on your machine and installs the ProofShot skill at user level. Run once per machine.
 
 ```bash
-proofshot init
-proofshot init --agent claude    # Specify agent type
-proofshot init --force           # Overwrite existing config
+proofshot install               # Interactive: select which tools to install for
+proofshot install --only claude  # Only install for specific tools
+proofshot install --skip cursor  # Skip specific tools
+proofshot install --force        # Overwrite even if already installed
 ```
 
 ### `proofshot start`
@@ -117,32 +110,17 @@ Remove artifact files.
 proofshot clean
 ```
 
-## Config
-
-`proofshot init` creates a `proofshot.config.json`:
-
-```json
-{
-  "devServer": {
-    "port": 3000,
-    "startupTimeout": 30000
-  },
-  "output": "./proofshot-artifacts",
-  "viewport": { "width": 1280, "height": 720 },
-  "headless": true
-}
-```
-
-The dev server command is provided at runtime via `--run`, not in the config. If `--run` is omitted, ProofShot assumes the server is already running.
-
 ## Supported Agents
 
-Skill files are provided for:
+`proofshot install` detects and installs skills for:
 
-- **Claude Code** — `.claude/skills/proofshot/SKILL.md`
-- **Cursor** — `.cursor/rules/proofshot.mdc`
-- **Codex** — Appends to `AGENTS.md`
-- **Generic** — `PROOFSHOT.md` in project root
+- **Claude Code** — `~/.claude/skills/proofshot/SKILL.md`
+- **Cursor** — `~/.cursor/rules/proofshot.mdc`
+- **Codex (OpenAI)** — `~/.codex/skills/proofshot/SKILL.md`
+- **Gemini CLI** — appends to `~/.gemini/GEMINI.md`
+- **Windsurf** — appends to `~/.codeium/windsurf/memories/global_rules.md`
+
+All skills are installed at the **user level** — works across every project without per-project setup.
 
 ## Try It — Sample App
 
@@ -163,7 +141,6 @@ npm link                    # makes `proofshot` available globally
 ```bash
 cd test/fixtures/sample-app
 npm install
-proofshot init --force
 ```
 
 ### 3. Tell your AI agent to verify it
@@ -172,7 +149,7 @@ Open your AI agent (Claude Code, Cursor, etc.) in the `test/fixtures/sample-app/
 
 > Verify the Acme SaaS sample app with proofshot. Start on the homepage, check the hero section and scroll down to see the feature cards and stats. Then navigate to the Dashboard and check the metrics and activity table. Finally go to Settings, update the profile name to "John Smith" and email to "john@acme.com", toggle on the Marketing emails and SMS alerts switches, and click Save Profile. Screenshot each page and every key interaction.
 
-The agent reads the skill file installed by `proofshot init`, runs the full `start → exec → stop` workflow autonomously, and produces the proof artifacts.
+The agent reads the skill file installed by `proofshot install`, runs the full `start → exec → stop` workflow autonomously, and produces the proof artifacts.
 
 ### 4. Check the output
 
@@ -192,7 +169,7 @@ cd test/fixtures/sample-app
 bash test-proofshot.sh
 ```
 
-This runs the full lifecycle: `init → start → browser interactions → stop → pr → clean`.
+This runs the full lifecycle: `start → browser interactions → stop → pr → clean`.
 
 Built on [agent-browser](https://github.com/vercel-labs/agent-browser) by Vercel.
 

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: proofshot
+description: Visual verification of UI features. Use after building or modifying any
+  UI component, page, or visual feature. Starts a verification session with video
+  recording and error capture, then you drive the browser to test, then stop to
+  bundle proof artifacts for the human.
+---
+
+# ProofShot — Visual Verification Workflow
+
+ProofShot is an open-source, agent-agnostic CLI that lets you verify your own work in a real browser — video proof, screenshots, and error reports, no vendor lock-in.
+
+## When to use
+
+Use ProofShot after:
+- Building a new UI feature or page
+- Modifying existing UI components
+- Fixing a visual bug
+- Any change that affects what the user sees
+
+## The workflow (always follow these 3 steps)
+
+### Step 1: Start the session
+
+```bash
+proofshot start --run "your-dev-command" --port PORT --description "what you are about to verify"
+```
+
+This opens a browser and begins recording. If --run is provided, it also starts and captures your dev server output.
+If the server is already running, omit --run (no server logs captured).
+The description appears in the proof report for the human.
+
+### Step 2: Drive the browser and test
+
+Use proofshot exec to navigate, interact, and verify:
+
+```bash
+proofshot exec snapshot -i                                    # See interactive elements
+proofshot exec open http://localhost:PORT/page                # Navigate to a page
+proofshot exec click @e3                                      # Click a button
+proofshot exec fill @e2 "test@example.com"                    # Fill a form field
+proofshot exec screenshot step-NAME.png                       # Capture key moments
+```
+
+Take screenshots at important moments — these become the visual proof.
+Verify what you expect to see by reading the snapshot output.
+
+### Step 3: Stop and bundle the proof
+
+```bash
+proofshot stop
+```
+
+This stops recording, collects console + server errors, and generates
+a SUMMARY.md with video, screenshots, and error report.
+
+## Tips
+
+- Always include a meaningful --description so the human knows what was tested
+- Take screenshots before AND after key actions (e.g., before form submit, after redirect)
+- If you find errors during verification, fix them and re-run the workflow
+- The proof artifacts in ./proofshot-artifacts/ can be referenced in commit messages or PRs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { initCommand } from './commands/init.js';
+import { installCommand } from './commands/install.js';
 import { startCommand } from './commands/start.js';
 import { stopCommand } from './commands/stop.js';
 import { diffCommand } from './commands/diff.js';
@@ -16,12 +16,13 @@ export function createCLI(): Command {
     .version('0.1.0');
 
   program
-    .command('init')
-    .description('Create config and install skill file')
-    .option('--agent <agent>', 'Agent type: claude, codex, cursor, gemini, copilot, generic')
-    .option('--force', 'Overwrite existing config')
+    .command('install')
+    .description('Install ProofShot skills at user level for all detected AI coding tools')
+    .option('--only <tools>', 'Only install for these tools (comma-separated: claude,codex,cursor,gemini,windsurf)')
+    .option('--skip <tools>', 'Skip these tools (comma-separated)')
+    .option('--force', 'Overwrite existing skill files even if unchanged')
     .action(async (options) => {
-      await initCommand(options);
+      await installCommand(options);
     });
 
   program

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,0 +1,461 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as readline from 'readline';
+import { execSync } from 'child_process';
+import chalk from 'chalk';
+import { readBundledSkill, getInlineSkillContent } from '../utils/skills.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ToolName = 'claude' | 'cursor' | 'codex' | 'gemini' | 'windsurf';
+
+type SkillTarget =
+  | { strategy: 'file'; relativePath: string }
+  | { strategy: 'append'; relativePath: string };
+
+interface ToolDefinition {
+  name: ToolName;
+  displayName: string;
+  binaryName: string;
+  configDir: string;
+  skillTarget: SkillTarget;
+  /** Path inside the bundled skills/ directory */
+  bundledSkill: string;
+  /** Fallback agent key for inline content generation */
+  inlineAgent: string;
+}
+
+interface InstallResult {
+  tool: ToolName;
+  displayName: string;
+  status: 'installed' | 'updated' | 'skipped' | 'failed';
+  path: string;
+  message?: string;
+}
+
+export interface InstallOptions {
+  only?: string;
+  skip?: string;
+  force?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MARKER_START = '<!-- proofshot:start -->';
+const MARKER_END = '<!-- proofshot:end -->';
+
+// ---------------------------------------------------------------------------
+// Tool registry
+// ---------------------------------------------------------------------------
+
+function getToolDefinitions(): ToolDefinition[] {
+  const home = os.homedir();
+  return [
+    {
+      name: 'claude',
+      displayName: 'Claude Code',
+      binaryName: 'claude',
+      configDir: path.join(home, '.claude'),
+      skillTarget: { strategy: 'file', relativePath: 'skills/proofshot/SKILL.md' },
+      bundledSkill: 'claude/SKILL.md',
+      inlineAgent: 'claude',
+    },
+    {
+      name: 'cursor',
+      displayName: 'Cursor',
+      binaryName: 'cursor',
+      configDir: path.join(home, '.cursor'),
+      skillTarget: { strategy: 'file', relativePath: 'rules/proofshot.mdc' },
+      bundledSkill: 'cursor/proofshot.mdc',
+      inlineAgent: 'cursor',
+    },
+    {
+      name: 'codex',
+      displayName: 'Codex (OpenAI)',
+      binaryName: 'codex',
+      configDir: path.join(home, '.codex'),
+      skillTarget: { strategy: 'file', relativePath: 'skills/proofshot/SKILL.md' },
+      bundledSkill: 'codex/SKILL.md',
+      inlineAgent: 'codex',
+    },
+    {
+      name: 'gemini',
+      displayName: 'Gemini CLI',
+      binaryName: 'gemini',
+      configDir: path.join(home, '.gemini'),
+      skillTarget: { strategy: 'append', relativePath: 'GEMINI.md' },
+      bundledSkill: 'generic/PROOFSHOT.md',
+      inlineAgent: 'generic',
+    },
+    {
+      name: 'windsurf',
+      displayName: 'Windsurf',
+      binaryName: 'windsurf',
+      configDir: path.join(home, '.codeium', 'windsurf'),
+      skillTarget: { strategy: 'append', relativePath: 'memories/global_rules.md' },
+      bundledSkill: 'generic/PROOFSHOT.md',
+      inlineAgent: 'generic',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+function isBinaryAvailable(binaryName: string): boolean {
+  const cmd = process.platform === 'win32' ? `where ${binaryName}` : `which ${binaryName}`;
+  try {
+    execSync(cmd, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectInstalledTools(): ToolDefinition[] {
+  return getToolDefinitions().filter(
+    (tool) => isBinaryAvailable(tool.binaryName) || fs.existsSync(tool.configDir),
+  );
+}
+
+function filterTools(
+  detected: ToolDefinition[],
+  only?: string,
+  skip?: string,
+): ToolDefinition[] {
+  let tools = detected;
+  if (only) {
+    const onlySet = new Set(only.split(',').map((s) => s.trim().toLowerCase()));
+    tools = tools.filter((t) => onlySet.has(t.name));
+  }
+  if (skip) {
+    const skipSet = new Set(skip.split(',').map((s) => s.trim().toLowerCase()));
+    tools = tools.filter((t) => !skipSet.has(t.name));
+  }
+  return tools;
+}
+
+// ---------------------------------------------------------------------------
+// Content resolution
+// ---------------------------------------------------------------------------
+
+function getSkillContent(tool: ToolDefinition): string {
+  return readBundledSkill(tool.bundledSkill) ?? getInlineSkillContent(tool.inlineAgent);
+}
+
+// ---------------------------------------------------------------------------
+// Installation strategies
+// ---------------------------------------------------------------------------
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function installFile(
+  tool: ToolDefinition,
+  targetPath: string,
+  content: string,
+  force: boolean,
+): InstallResult {
+  const exists = fs.existsSync(targetPath);
+  if (exists && !force) {
+    const existing = fs.readFileSync(targetPath, 'utf-8');
+    if (existing === content) {
+      return {
+        tool: tool.name,
+        displayName: tool.displayName,
+        status: 'skipped',
+        path: targetPath,
+        message: 'Already up to date',
+      };
+    }
+  }
+
+  fs.writeFileSync(targetPath, content);
+  return {
+    tool: tool.name,
+    displayName: tool.displayName,
+    status: exists ? 'updated' : 'installed',
+    path: targetPath,
+  };
+}
+
+function installAppend(
+  tool: ToolDefinition,
+  targetPath: string,
+  content: string,
+  force: boolean,
+): InstallResult {
+  const markedContent = `${MARKER_START}\n${content}\n${MARKER_END}`;
+  const exists = fs.existsSync(targetPath);
+
+  if (exists) {
+    const existing = fs.readFileSync(targetPath, 'utf-8');
+
+    if (existing.includes(MARKER_START)) {
+      // Replace existing marked block
+      const regex = new RegExp(
+        `${escapeRegex(MARKER_START)}[\\s\\S]*?${escapeRegex(MARKER_END)}`,
+      );
+      const updated = existing.replace(regex, markedContent);
+
+      if (updated === existing && !force) {
+        return {
+          tool: tool.name,
+          displayName: tool.displayName,
+          status: 'skipped',
+          path: targetPath,
+          message: 'Already up to date',
+        };
+      }
+
+      fs.writeFileSync(targetPath, updated);
+      return {
+        tool: tool.name,
+        displayName: tool.displayName,
+        status: 'updated',
+        path: targetPath,
+      };
+    }
+
+    // No markers found — append
+    fs.appendFileSync(targetPath, '\n\n' + markedContent + '\n');
+    return {
+      tool: tool.name,
+      displayName: tool.displayName,
+      status: 'installed',
+      path: targetPath,
+    };
+  }
+
+  // File does not exist — create
+  fs.writeFileSync(targetPath, markedContent + '\n');
+  return {
+    tool: tool.name,
+    displayName: tool.displayName,
+    status: 'installed',
+    path: targetPath,
+  };
+}
+
+function installForTool(tool: ToolDefinition, force: boolean): InstallResult {
+  const content = getSkillContent(tool);
+  const targetPath = path.join(tool.configDir, tool.skillTarget.relativePath);
+  const targetDir = path.dirname(targetPath);
+
+  try {
+    fs.mkdirSync(targetDir, { recursive: true });
+
+    if (tool.skillTarget.strategy === 'file') {
+      return installFile(tool, targetPath, content, force);
+    } else {
+      return installAppend(tool, targetPath, content, force);
+    }
+  } catch (error: any) {
+    return {
+      tool: tool.name,
+      displayName: tool.displayName,
+      status: 'failed',
+      path: targetPath,
+      message: error.message,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Interactive prompt
+// ---------------------------------------------------------------------------
+
+function checkboxSelect(tools: ToolDefinition[]): Promise<ToolDefinition[]> {
+  return new Promise((resolve) => {
+    const selected = new Array(tools.length).fill(true);
+    let cursor = 0;
+
+    function render() {
+      // Move cursor up to overwrite previous render (except first)
+      if (renderCount > 0) {
+        process.stdout.write(`\x1b[${tools.length + 2}A`);
+      }
+      renderCount++;
+
+      console.log(chalk.bold('Select tools to install:'));
+      console.log('');
+      for (let i = 0; i < tools.length; i++) {
+        const check = selected[i] ? chalk.green('[x]') : chalk.dim('[ ]');
+        const label = tools[i].displayName;
+        const pointer = i === cursor ? chalk.green('> ') : '  ';
+        console.log(`${pointer}${check} ${label}`);
+      }
+    }
+
+    let renderCount = 0;
+    render();
+    console.log('');
+    process.stdout.write(chalk.dim('  ↑/↓ navigate · space toggle · enter confirm'));
+
+    const stdin = process.stdin;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf-8');
+
+    function onData(key: string) {
+      // Ctrl+C
+      if (key === '\x03') {
+        stdin.setRawMode(false);
+        stdin.removeListener('data', onData);
+        stdin.pause();
+        // Clear the hint line and move down
+        process.stdout.write('\r\x1b[K\n');
+        resolve([]);
+        return;
+      }
+
+      // Enter
+      if (key === '\r' || key === '\n') {
+        stdin.setRawMode(false);
+        stdin.removeListener('data', onData);
+        stdin.pause();
+        // Clear the hint line and move down
+        process.stdout.write('\r\x1b[K\n');
+        resolve(tools.filter((_, i) => selected[i]));
+        return;
+      }
+
+      // Space — toggle
+      if (key === ' ') {
+        selected[cursor] = !selected[cursor];
+        // Move up to re-render hint, then re-render
+        process.stdout.write('\r\x1b[K');
+        process.stdout.write(`\x1b[1A`);
+        render();
+        console.log('');
+        process.stdout.write(chalk.dim('  ↑/↓ navigate · space toggle · enter confirm'));
+        return;
+      }
+
+      // Arrow up
+      if (key === '\x1b[A') {
+        cursor = (cursor - 1 + tools.length) % tools.length;
+        process.stdout.write('\r\x1b[K');
+        process.stdout.write(`\x1b[1A`);
+        render();
+        console.log('');
+        process.stdout.write(chalk.dim('  ↑/↓ navigate · space toggle · enter confirm'));
+        return;
+      }
+
+      // Arrow down
+      if (key === '\x1b[B') {
+        cursor = (cursor + 1) % tools.length;
+        process.stdout.write('\r\x1b[K');
+        process.stdout.write(`\x1b[1A`);
+        render();
+        console.log('');
+        process.stdout.write(chalk.dim('  ↑/↓ navigate · space toggle · enter confirm'));
+        return;
+      }
+    }
+
+    stdin.on('data', onData);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main command
+// ---------------------------------------------------------------------------
+
+export async function installCommand(options: InstallOptions): Promise<void> {
+  const allDetected = detectInstalledTools();
+  const tools = filterTools(allDetected, options.only, options.skip);
+
+  if (tools.length === 0) {
+    if (options.only || options.skip) {
+      console.log(chalk.yellow('No matching AI tools found after applying filters.'));
+      console.log(
+        chalk.dim(
+          'Detected tools: ' + (allDetected.map((t) => t.name).join(', ') || 'none'),
+        ),
+      );
+    } else {
+      console.log(chalk.yellow('No AI coding tools detected on this machine.'));
+      console.log(chalk.dim('Looked for: claude, cursor, codex, gemini, windsurf'));
+    }
+    return;
+  }
+
+  // Interactive selection (or install all if non-interactive)
+  let selectedTools = tools;
+  if (process.stdin.isTTY) {
+    console.log('');
+    const picked = await checkboxSelect(tools);
+    if (picked.length === 0) {
+      console.log(chalk.dim('Aborted.'));
+      return;
+    }
+    selectedTools = picked;
+  } else {
+    console.log('');
+    console.log(chalk.bold('Detected AI coding tools:'));
+    console.log('');
+    for (const tool of tools) {
+      console.log(`  ${chalk.green('\u25cf')} ${tool.displayName}`);
+    }
+    console.log('');
+  }
+
+  // Install for each tool
+  const results: InstallResult[] = [];
+  for (const tool of selectedTools) {
+    const result = installForTool(tool, !!options.force);
+    results.push(result);
+
+    const icon =
+      result.status === 'failed'
+        ? chalk.red('\u2717')
+        : result.status === 'skipped'
+          ? chalk.dim('\u2013')
+          : chalk.green('\u2713');
+    const statusText =
+      result.status === 'installed'
+        ? 'Installed'
+        : result.status === 'updated'
+          ? 'Updated'
+          : result.status === 'skipped'
+            ? 'Skipped'
+            : 'Failed';
+    const suffix = result.message ? chalk.dim(` (${result.message})`) : '';
+
+    console.log(`${icon} ${tool.displayName}: ${statusText}${suffix}`);
+    if (result.status !== 'failed') {
+      console.log(chalk.dim(`  \u2192 ${result.path}`));
+    } else if (result.message) {
+      console.log(chalk.red(`  ${result.message}`));
+    }
+  }
+
+  // Summary
+  const installed = results.filter(
+    (r) => r.status === 'installed' || r.status === 'updated',
+  ).length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  console.log('');
+
+  if (failed > 0) {
+    console.log(chalk.yellow(`Done. ${installed} installed, ${failed} failed.`));
+  } else if (installed > 0) {
+    console.log(chalk.green(`Done! ProofShot skills installed for ${installed} tool(s).`));
+    console.log('');
+    console.log(`You're all set! In any project, tell your AI agent:`);
+    console.log('');
+    console.log(chalk.white(`  "Verify the changes visually with proofshot"`));
+    console.log('');
+  } else {
+    console.log(chalk.dim('All tools already up to date.'));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Public API
 export { createCLI } from './cli.js';
+export { installCommand } from './commands/install.js';
 export { ensureDevServer } from './server/start.js';
 export { loadConfig, writeConfig, type ProofShotConfig } from './utils/config.js';
 export { ab, ProofShotError } from './utils/exec.js';

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -1,50 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import chalk from 'chalk';
-import { writeConfig, configExists, type ProofShotConfig } from '../utils/config.js';
 
-interface InitOptions {
-  agent?: string;
-  force?: boolean;
-}
-
-const SKILL_FILES: Record<string, { path: string; content: () => string }> = {
-  claude: {
-    path: '.claude/skills/proofshot/SKILL.md',
-    content: () =>
-      fs.readFileSync(
-        path.join(getSkillsDir(), 'claude', 'SKILL.md'),
-        'utf-8',
-      ),
-  },
-  cursor: {
-    path: '.cursor/rules/proofshot.mdc',
-    content: () =>
-      fs.readFileSync(
-        path.join(getSkillsDir(), 'cursor', 'proofshot.mdc'),
-        'utf-8',
-      ),
-  },
-  codex: {
-    path: 'AGENTS.md',
-    content: () =>
-      fs.readFileSync(
-        path.join(getSkillsDir(), 'codex', 'AGENTS.md'),
-        'utf-8',
-      ),
-  },
-  generic: {
-    path: 'PROOFSHOT.md',
-    content: () =>
-      fs.readFileSync(
-        path.join(getSkillsDir(), 'generic', 'PROOFSHOT.md'),
-        'utf-8',
-      ),
-  },
-};
-
-function getSkillsDir(): string {
-  // Skills are shipped alongside the package
+/**
+ * Resolve the directory where bundled skill files are shipped.
+ */
+export function getSkillsDir(): string {
   return path.resolve(
     path.dirname(new URL(import.meta.url).pathname),
     '..', '..', 'skills',
@@ -52,59 +12,21 @@ function getSkillsDir(): string {
 }
 
 /**
- * Detect which agent is likely being used based on project files.
+ * Read a bundled skill file. Returns the content string, or null if not found.
  */
-function detectAgent(): string {
-  const cwd = process.cwd();
-  if (fs.existsSync(path.join(cwd, '.claude'))) return 'claude';
-  if (fs.existsSync(path.join(cwd, '.cursor'))) return 'cursor';
-  if (fs.existsSync(path.join(cwd, 'AGENTS.md'))) return 'codex';
-  return 'generic';
-}
-
-/**
- * Install the skill file for the detected/selected agent.
- */
-function installSkillFile(agent: string): string | null {
-  const skill = SKILL_FILES[agent] || SKILL_FILES.generic;
-
+export function readBundledSkill(relativePath: string): string | null {
   try {
-    const content = skill.content();
-    const targetPath = path.join(process.cwd(), skill.path);
-    const targetDir = path.dirname(targetPath);
-
-    fs.mkdirSync(targetDir, { recursive: true });
-
-    // For AGENTS.md, append rather than overwrite if it exists
-    if (agent === 'codex' && fs.existsSync(targetPath)) {
-      const existing = fs.readFileSync(targetPath, 'utf-8');
-      if (!existing.includes('ProofShot')) {
-        fs.appendFileSync(targetPath, '\n\n' + content);
-      }
-    } else {
-      fs.writeFileSync(targetPath, content);
-    }
-
-    return skill.path;
+    return fs.readFileSync(path.join(getSkillsDir(), relativePath), 'utf-8');
   } catch {
-    // If skill files aren't bundled (dev mode), create inline
-    return createInlineSkillFile(agent);
+    return null;
   }
 }
 
-function createInlineSkillFile(agent: string): string | null {
-  const skillContent = getInlineSkillContent(agent);
-  const skill = SKILL_FILES[agent] || SKILL_FILES.generic;
-  const targetPath = path.join(process.cwd(), skill.path);
-  const targetDir = path.dirname(targetPath);
-
-  fs.mkdirSync(targetDir, { recursive: true });
-  fs.writeFileSync(targetPath, skillContent);
-  return skill.path;
-}
-
-function getInlineSkillContent(agent: string): string {
-  if (agent === 'claude') {
+/**
+ * Generate inline skill content as a fallback when bundled files aren't available.
+ */
+export function getInlineSkillContent(agent: string): string {
+  if (agent === 'claude' || agent === 'codex') {
     return `---
 name: proofshot
 description: Visual verification of UI features. Use after building or modifying any
@@ -190,7 +112,7 @@ Key proofshot exec commands:
 `;
   }
 
-  // Generic / codex
+  // Generic / gemini / windsurf
   return `# ProofShot Visual Verification
 
 After building or modifying UI features, verify with this workflow:
@@ -208,53 +130,4 @@ Key proofshot exec commands:
 
 Artifacts saved to ./proofshot-artifacts/ including video, screenshots, errors, and summary.
 `;
-}
-
-export async function initCommand(options: InitOptions): Promise<void> {
-  const cwd = process.cwd();
-
-  // Check for existing config
-  if (configExists() && !options.force) {
-    console.log(
-      chalk.yellow('proofshot.config.json already exists. Use --force to overwrite.'),
-    );
-    return;
-  }
-
-  // Build config with defaults
-  const config: ProofShotConfig = {
-    devServer: {
-      port: 3000,
-      startupTimeout: 30000,
-    },
-    output: './proofshot-artifacts',
-    defaultPages: ['/'],
-    viewport: { width: 1280, height: 720 },
-    headless: true,
-  };
-
-  // Write config
-  const configPath = writeConfig(config, cwd);
-  console.log(
-    chalk.green('✓') +
-      ` Created ${chalk.bold('proofshot.config.json')}`,
-  );
-
-  // Detect/select agent and install skill file
-  const agent = options.agent || detectAgent();
-  const skillPath = installSkillFile(agent);
-  if (skillPath) {
-    console.log(
-      chalk.green('✓') +
-        ` Installed skill file: ${chalk.bold(skillPath)}` +
-        ` (${agent})`,
-    );
-  }
-
-  console.log('');
-  console.log(chalk.dim('Ready! Tell your AI agent:'));
-  console.log(chalk.white('  "Verify the changes visually with proofshot"'));
-  console.log('');
-  console.log(chalk.dim('Or run directly:'));
-  console.log(chalk.white('  proofshot verify --pages "/"'));
 }

--- a/test/fixtures/sample-app/test-proofshot.sh
+++ b/test/fixtures/sample-app/test-proofshot.sh
@@ -7,18 +7,13 @@ PROOFSHOT="node $(dirname "$0")/../../../dist/bin/proofshot.js"
 echo "=== ProofShot E2E Test ==="
 echo ""
 
-# Step 1: Init
-echo "--- Step 1: proofshot init ---"
-$PROOFSHOT init --force
-echo ""
-
-# Step 2: Start session
-echo "--- Step 2: proofshot start ---"
+# Step 1: Start session
+echo "--- Step 1: proofshot start ---"
 $PROOFSHOT start --run "npm run dev" --port 5173 --description "Verify all 3 pages load: home, dashboard, settings"
 echo ""
 
-# Step 3: Agent drives the browser
-echo "--- Step 3: Agent testing with agent-browser ---"
+# Step 2: Agent drives the browser
+echo "--- Step 2: Agent testing with agent-browser ---"
 agent-browser snapshot -i
 agent-browser screenshot ./proofshot-artifacts/step-home.png
 agent-browser open http://localhost:5173/dashboard.html
@@ -27,25 +22,25 @@ agent-browser open http://localhost:5173/settings.html
 agent-browser screenshot ./proofshot-artifacts/step-settings.png
 echo ""
 
-# Step 4: Stop session
-echo "--- Step 4: proofshot stop ---"
+# Step 3: Stop session
+echo "--- Step 3: proofshot stop ---"
 $PROOFSHOT stop
 echo ""
 
-# Step 5: Check artifacts
-echo "--- Step 5: Check artifacts ---"
+# Step 4: Check artifacts
+echo "--- Step 4: Check artifacts ---"
 ls -la proofshot-artifacts/
 echo ""
 cat proofshot-artifacts/SUMMARY.md
 echo ""
 
-# Step 6: PR format
-echo "--- Step 6: proofshot pr ---"
+# Step 5: PR format
+echo "--- Step 5: proofshot pr ---"
 $PROOFSHOT pr
 echo ""
 
-# Step 7: Clean
-echo "--- Step 7: proofshot clean ---"
+# Step 6: Clean
+echo "--- Step 6: proofshot clean ---"
 $PROOFSHOT clean
 echo ""
 


### PR DESCRIPTION
Replace per-project skill setup with user-level installation. New `proofshot install` command detects AI coding tools on the machine and installs skills at user level so they work across all projects automatically. Removes `proofshot init` and includes interactive checkbox UI for tool selection, cross-platform binary detection, idempotent installation with marker-based updates, and support for all 5 AI coding tools (Claude Code, Cursor, Codex, Gemini CLI, Windsurf).

Changes:
- New `src/commands/install.ts` with detection, filtering, and installation logic
- Extract shared skill utilities to `src/utils/skills.ts`
- Add Codex-format skill file at `skills/codex/SKILL.md`
- Update documentation and test scripts to reflect new workflow