### PR TITLE
Add automated npm publishing with semantic-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: Publish to NPM
+
+on:
+  push:
+    branches: [main]
+
+# Prevent concurrent releases
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  # First, verify the build works
+  build:
+    name: Build and Verify
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for semantic-release to analyze commits
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify build artifacts
+        run: |
+          test -f dist/bin/proofshot.js || exit 1
+          test -f dist/src/index.js || exit 1
+
+      - name: Run tests
+        run: npm test
+
+  # Publish after build succeeds
+  publish:
+    name: Publish to NPM
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Required for pushing tags and releases
+      issues: write # Required for commenting on issues
+      pull-requests: write # Required for commenting on PRs
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Semantic Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx --package semantic-release@24 --package @semantic-release/changelog --package @semantic-release/git --package conventional-changelog-conventionalcommits semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,57 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "docs", "release": false },
+          { "type": "style", "release": false },
+          { "type": "chore", "release": false },
+          { "type": "test", "release": false },
+          { "type": "ci", "release": false },
+          { "breaking": true, "release": "major" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance" },
+            { "type": "refactor", "section": "Refactoring" },
+            { "type": "docs", "section": "Documentation", "hidden": true },
+            { "type": "style", "section": "Styles", "hidden": true },
+            { "type": "chore", "section": "Chores", "hidden": true },
+            { "type": "test", "section": "Tests", "hidden": true },
+            { "type": "ci", "section": "CI", "hidden": true }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/npm",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,18 @@ Edit `src/utils/error-patterns.ts` — add a new entry to the `PATTERNS` array:
 | `SUMMARY.md` | `stop` | Markdown report with errors and screenshots |
 | `viewer.html` | `stop` | Standalone HTML viewer with video + timeline |
 
+## Versioning & releases
+
+- **Automatic** — merging to `main` triggers semantic-release via GitHub Actions
+- **Never manually edit `version` in package.json** — semantic-release handles it
+- **Conventional Commits** determine the version bump:
+  - `feat:` → minor (0.1.0 → 0.2.0)
+  - `fix:`, `perf:`, `refactor:` → patch (0.2.0 → 0.2.1)
+  - `feat!:` or `BREAKING CHANGE:` footer → major (0.2.1 → 1.0.0)
+  - `docs:`, `style:`, `chore:`, `test:`, `ci:` → no release
+- **Commit format:** `type(scope): description` — e.g. `feat(cli): add diff command`, `fix(viewer): correct timestamp offset`
+- **Branch naming:** `AmElmo/<descriptive-name>`
+
 ## Gotchas
 
 - `proofshot exec` has special shell quoting logic (`buildShellCommand` in exec.ts) — `eval` commands get single-quoted, args with special chars get auto-quoted

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/proofshot/proofshot"
+    "url": "https://github.com/AmElmo/proofshot.git"
   }
 }


### PR DESCRIPTION
## Summary

Implements automated semantic versioning and npm publishing using semantic-release. Adds a GitHub Actions workflow that triggers on pushes to main, runs tests and builds, then automatically publishes to npm with version bumping based on conventional commit types.

Includes .releaserc.json configuration that enforces conventional commits, automatically generates CHANGELOG.md, and pushes release commits back to the repository. Updated CLAUDE.md with versioning conventions and repository URL to support the new publishing workflow.

This enables automatic releases on merge to main without manual version management.