### PR TITLE
Add Umami analytics tracking to docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="c8819712-abe9-42ed-bec1-c11b5c0602b7"></script>
   <style>
     *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 


### PR DESCRIPTION
Adds Umami Web analytics tracking to the ProofShot documentation landing page. The tracking script is configured with the website ID and will begin collecting analytics once deployed to GitHub Pages.