### PR TITLE
Fix license badge repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/proofshot"><img src="https://img.shields.io/npm/v/proofshot?color=0ea5e9" alt="npm version"></a>
-  <a href="https://github.com/proofshot/proofshot/blob/main/LICENSE"><img src="https://img.shields.io/github/license/proofshot/proofshot" alt="license"></a>
+  <a href="https://github.com/AmElmo/proofshot/blob/main/LICENSE"><img src="https://img.shields.io/github/license/AmElmo/proofshot" alt="license"></a>
   <a href="https://www.npmjs.com/package/proofshot"><img src="https://img.shields.io/npm/dm/proofshot?color=6366f1" alt="downloads"></a>
 </p>
 


### PR DESCRIPTION
Corrects the license badge in README.md to point to the actual repository (AmElmo/proofshot) instead of the nonexistent proofshot/proofshot. Fixes shields.io returning 'repo not found' for the license badge.