### PR TITLE
docs: add footer credit to AmElmo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1442,6 +1442,7 @@
 <footer>
   <div class="footer-inner">
     <span>ProofShot &mdash; MIT License</span>
+    <span>✨ Built with love by <a href="https://github.com/amelmo" style="color: var(--accent); text-decoration: none;">AmElmo</a></span>
     <div class="footer-links">
       <a href="https://github.com/AmElmo/proofshot">GitHub</a>
       <a href="https://www.npmjs.com/package/proofshot">npm</a>


### PR DESCRIPTION
Add a footer credit to the landing page linking to the creator's GitHub profile.