### PR TITLE
fix: correct token usage totals in reports

### DIFF
--- a/src/artifacts/viewer.ts
+++ b/src/artifacts/viewer.ts
@@ -19,6 +19,13 @@ interface ViewerData {
   serverLog?: string;
   consoleEntries?: TimestampedLogEntry[];
   serverEntries?: TimestampedLogEntry[];
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    estimatedCost: number;
+    source: string;
+  } | null;
 }
 
 /** Maximum log size embedded in the viewer HTML (50 KB). */
@@ -161,6 +168,19 @@ export function generateViewer(data: ViewerData): string {
     data.serverErrorCount === 0
       ? 'Server: clean'
       : `Server: ${data.serverErrorCount} error(s)`;
+
+  const tokenUsageHtml = data.tokenUsage
+    ? `<div class="token-usage">
+      <div class="token-usage-title">Token Usage (Estimated)</div>
+      <div class="token-usage-values">
+        <span>In: ~${data.tokenUsage.inputTokens.toLocaleString()}</span>
+        <span>Out: ~${data.tokenUsage.outputTokens.toLocaleString()}</span>
+        <span>Total: ~${data.tokenUsage.totalTokens.toLocaleString()}</span>
+        ${data.tokenUsage.estimatedCost > 0 ? `<span>Cost: ~$${data.tokenUsage.estimatedCost.toFixed(4)}</span>` : ''}
+      </div>
+      ${data.tokenUsage.source === 'estimated' ? '<div class="token-usage-note">Estimated from session activity</div>' : ''}
+    </div>`
+    : '';
 
   const hasVideo = !!data.videoFilename;
 
@@ -374,6 +394,37 @@ export function generateViewer(data: ViewerData): string {
       display: flex;
       gap: 12px;
       margin-top: 10px;
+    }
+
+    .token-usage {
+      margin-top: 12px;
+      padding: 10px 12px;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      background: #0d1117;
+      max-width: fit-content;
+    }
+
+    .token-usage-title {
+      font-size: 12px;
+      color: #f0f6fc;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+
+    .token-usage-values {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      font-size: 12px;
+      color: #8b949e;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .token-usage-note {
+      margin-top: 6px;
+      font-size: 11px;
+      color: #6e7681;
     }
 
     .error-badge {
@@ -889,6 +940,7 @@ export function generateViewer(data: ViewerData): string {
       <button class="error-badge ${consoleBadgeClass}" onclick="switchTab('console')"><span class="badge-dot"></span>${consoleBadgeText}</button>
       <button class="error-badge ${serverBadgeClass}" onclick="switchTab('server')"><span class="badge-dot"></span>${serverBadgeText}</button>
     </div>
+    ${tokenUsageHtml}
   </div>
   <div class="viewer">
     <div class="video-panel">

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -9,6 +9,7 @@ import { loadSession, clearSession } from '../session/state.js';
 import { writeViewer, type TimestampedLogEntry } from '../artifacts/viewer.js';
 import { extractServerErrors } from '../utils/error-patterns.js';
 import { loadSessionLog } from './exec.js';
+import { estimateTokenUsage, formatTokenUsage, type TokenUsage } from '../utils/token-usage.js';
 
 /**
  * Parse server.log lines with "epochMs\ttext" format.
@@ -144,6 +145,9 @@ export async function stopCommand(options: StopOptions): Promise<void> {
   const serverErrorLines = extractServerErrors(serverLog);
   const serverErrorCount = serverErrorLines.length;
 
+  // Step 6.5: Estimate token usage
+  const tokenUsage = estimateTokenUsage(session.sessionDir, startTime, Date.now());
+
   // Step 7: Generate SUMMARY.md
   const summaryPath = path.join(sessionDir, 'SUMMARY.md');
   const summary = generateProofSummary({
@@ -156,6 +160,7 @@ export async function stopCommand(options: StopOptions): Promise<void> {
     consoleErrorCount,
     serverLog,
     serverErrorCount,
+    tokenUsage,
     durationSec,
     outputDir: sessionDir,
   });
@@ -198,6 +203,7 @@ export async function stopCommand(options: StopOptions): Promise<void> {
     consoleEntries: viewerConsoleEntries.length > 0 ? viewerConsoleEntries : undefined,
     serverEntries: viewerServerEntries.length > 0 ? viewerServerEntries : undefined,
     entries: viewerEntries.length > 0 ? viewerEntries : undefined,
+    tokenUsage,
   });
 
   // Step 8: Clear session state
@@ -263,6 +269,7 @@ interface SummaryData {
   consoleErrorCount: number;
   serverLog: string;
   serverErrorCount: number;
+  tokenUsage?: TokenUsage | null;
   durationSec: number;
   outputDir: string;
 }
@@ -326,6 +333,12 @@ Full session recording: [${relativeVideo}](./${relativeVideo}) (${data.durationS
     if (data.serverLog.length > 5000) {
       md += `_(truncated — see server.log for full output)_\n\n`;
     }
+  }
+
+  if (data.tokenUsage) {
+    md += `## Token Usage (Estimated)\n\n`;
+    md += formatTokenUsage(data.tokenUsage);
+    md += '\n';
   }
 
   // Environment

--- a/src/utils/token-usage.test.ts
+++ b/src/utils/token-usage.test.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { estimateTokenUsage } from './token-usage.js';
+
+describe('estimateTokenUsage', () => {
+  let originalHome: string | undefined;
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    originalHome = undefined;
+  });
+
+  it('computes total tokens from usage fields when top-level totals are missing', () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'proofshot-token-home-'));
+    const claudeSessionsDir = path.join(tmpHome, '.claude', 'sessions');
+    fs.mkdirSync(claudeSessionsDir, { recursive: true });
+
+    const now = Date.now();
+    const startedAt = new Date(now).toISOString();
+
+    fs.writeFileSync(
+      path.join(claudeSessionsDir, 'session.json'),
+      JSON.stringify({
+        startedAt,
+        usage: {
+          inputTokens: 1200,
+          outputTokens: 300,
+        },
+      }),
+    );
+
+    const sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proofshot-token-session-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+
+    const usage = estimateTokenUsage(sessionDir, now - 1000, now + 1000);
+
+    expect(usage).not.toBeNull();
+    expect(usage?.inputTokens).toBe(1200);
+    expect(usage?.outputTokens).toBe(300);
+    expect(usage?.totalTokens).toBe(1500);
+    expect(usage?.source).toBe('claude-logs');
+  });
+});

--- a/src/utils/token-usage.ts
+++ b/src/utils/token-usage.ts
@@ -36,11 +36,13 @@ function tryClaudeCodeLogs(startTimeMs: number, endTimeMs: number): TokenUsage |
       const data = JSON.parse(fs.readFileSync(path.join(claudeDir, file), 'utf-8'));
       const sessionStart = new Date(data.startedAt).getTime();
       if (sessionStart >= startTimeMs - 60000 && sessionStart <= endTimeMs + 60000) {
-        if (data.totalInputTokens || data.usage) {
+        if (data.totalInputTokens != null || data.totalOutputTokens != null || data.usage) {
+          const inputTokens = data.totalInputTokens ?? data.usage?.inputTokens ?? 0;
+          const outputTokens = data.totalOutputTokens ?? data.usage?.outputTokens ?? 0;
           return {
-            inputTokens: data.totalInputTokens || data.usage?.inputTokens || 0,
-            outputTokens: data.totalOutputTokens || data.usage?.outputTokens || 0,
-            totalTokens: (data.totalInputTokens || 0) + (data.totalOutputTokens || 0),
+            inputTokens,
+            outputTokens,
+            totalTokens: inputTokens + outputTokens,
             estimatedCost: 0,
             model: data.model || 'claude',
             source: 'claude-logs',

--- a/src/utils/token-usage.ts
+++ b/src/utils/token-usage.ts
@@ -1,0 +1,98 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  estimatedCost: number;
+  model: string;
+  source: 'claude-logs' | 'estimated' | 'unavailable';
+}
+
+/**
+ * Attempt to estimate token usage for a ProofShot session.
+ * Tries Claude Code logs first, falls back to content-based estimation.
+ */
+export function estimateTokenUsage(
+  sessionDir: string,
+  startTimeMs: number,
+  endTimeMs: number,
+): TokenUsage | null {
+  const claudeUsage = tryClaudeCodeLogs(startTimeMs, endTimeMs);
+  if (claudeUsage) return claudeUsage;
+
+  return estimateFromContent(sessionDir);
+}
+
+function tryClaudeCodeLogs(startTimeMs: number, endTimeMs: number): TokenUsage | null {
+  const claudeDir = path.join(os.homedir(), '.claude', 'sessions');
+  if (!fs.existsSync(claudeDir)) return null;
+
+  try {
+    const files = fs.readdirSync(claudeDir).filter((f) => f.endsWith('.json'));
+    for (const file of files) {
+      const data = JSON.parse(fs.readFileSync(path.join(claudeDir, file), 'utf-8'));
+      const sessionStart = new Date(data.startedAt).getTime();
+      if (sessionStart >= startTimeMs - 60000 && sessionStart <= endTimeMs + 60000) {
+        if (data.totalInputTokens || data.usage) {
+          return {
+            inputTokens: data.totalInputTokens || data.usage?.inputTokens || 0,
+            outputTokens: data.totalOutputTokens || data.usage?.outputTokens || 0,
+            totalTokens: (data.totalInputTokens || 0) + (data.totalOutputTokens || 0),
+            estimatedCost: 0,
+            model: data.model || 'claude',
+            source: 'claude-logs',
+          };
+        }
+      }
+    }
+  } catch {
+    // Silent fallback
+  }
+
+  return null;
+}
+
+function estimateFromContent(sessionDir: string): TokenUsage | null {
+  const logPath = path.join(sessionDir, 'session-log.json');
+  if (!fs.existsSync(logPath)) return null;
+
+  try {
+    const entries = JSON.parse(fs.readFileSync(logPath, 'utf-8'));
+    if (!Array.isArray(entries) || entries.length === 0) return null;
+
+    const actionCount = entries.length;
+    const inputTokens = actionCount * 500;
+    const outputTokens = actionCount * 300;
+    const totalTokens = inputTokens + outputTokens;
+    const estimatedCost = (inputTokens * 3 + outputTokens * 15) / 1_000_000;
+
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      estimatedCost,
+      model: 'estimated',
+      source: 'estimated',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function formatTokenUsage(usage: TokenUsage): string {
+  const fmt = (n: number) => n.toLocaleString();
+  let result = '';
+  result += `- Input tokens: ~${fmt(usage.inputTokens)}\n`;
+  result += `- Output tokens: ~${fmt(usage.outputTokens)}\n`;
+  result += `- Total tokens: ~${fmt(usage.totalTokens)}\n`;
+  if (usage.estimatedCost > 0) {
+    result += `- Estimated cost: ~$${usage.estimatedCost.toFixed(4)}\n`;
+  }
+  if (usage.source === 'estimated') {
+    result += `- Source: estimated from ${usage.model === 'estimated' ? 'session activity' : usage.model}\n`;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Adds token usage estimation to SUMMARY.md and the HTML viewer after `proofshot stop`. Addresses the core request in #2 by showing input/output/total tokens and estimated cost.

## Approach

The implementation uses a two-tier strategy:

1. Checks Claude Code session logs (`~/.claude/sessions/`) for sessions overlapping with the recording window. Currently Claude Code doesn't expose token counts in these files, but this path is ready for when that data becomes available.

2. Falls back to estimating from session activity - each logged action in `session-log.json` represents an AI interaction, so we estimate ~500 input + ~300 output tokens per action. Cost estimates use Claude Sonnet 4.6 pricing ($3/MTok input, $15/MTok output).

## Changes

- `src/utils/token-usage.ts` (new): Token estimation module with `estimateTokenUsage()` and `formatTokenUsage()` functions
- `src/commands/stop.ts`: Integrates token estimation into the stop flow, adds Token Usage section to SUMMARY.md
- `src/artifacts/viewer.ts`: Adds token usage panel to the HTML viewer

## Testing

- `npm run build` succeeds
- `npm test` passes (8/8 tests)
- Token usage section gracefully omitted when no session log exists

## Open questions from the issue

This PR tackles the "agent log parsing" and "estimation" approaches. The local proxy approach and per-agent integrations are left for follow-up work as more agents expose usage data.

Fixes #2

This contribution was developed with AI assistance (Codex).