### PR TITLE
fix: isolate each ProofShot run in one agent-browser session

### DIFF
--- a/PROOFSHOT.md
+++ b/PROOFSHOT.md
@@ -9,6 +9,8 @@ After building or modifying UI features, verify with this workflow:
 2. Test: Use `proofshot exec` to navigate, click, fill forms, take screenshots
 3. Stop: `proofshot stop` — bundles video, screenshots, and error report
 
+ProofShot keeps all `proofshot exec` commands inside the same isolated `agent-browser` session that was created by `proofshot start`, so recording, screenshots, and browser actions stay aligned.
+
 Key proofshot exec commands:
 - `proofshot exec snapshot -i` — see interactive elements
 - `proofshot exec click @e3` — click an element

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ proofshot stop --no-close   # Stop but keep browser open
 
 Pass-through to agent-browser with automatic session logging. Captures timestamps, element data, and resolves screenshot paths.
 
+When a ProofShot session is active, `proofshot exec` reuses the same isolated `agent-browser` session that `proofshot start` created for that run. This keeps screenshots, console logs, video recording, and browser actions pointed at the same browser session.
+
 ```bash
 proofshot exec click @e3
 proofshot exec screenshot step-checkout.png

--- a/src/browser/capture.ts
+++ b/src/browser/capture.ts
@@ -3,16 +3,16 @@ import { ab } from '../utils/exec.js';
 /**
  * Start video recording to the given file path.
  */
-export function startRecording(outputPath: string): void {
-  ab(`record start ${outputPath}`, 10000);
+export function startRecording(outputPath: string, sessionName?: string): void {
+  ab(`record start ${outputPath}`, { timeoutMs: 10000, session: sessionName });
 }
 
 /**
  * Stop the current recording.
  */
-export function stopRecording(): void {
+export function stopRecording(sessionName?: string): void {
   try {
-    ab('record stop', 15000);
+    ab('record stop', { timeoutMs: 15000, session: sessionName });
   } catch {
     // Recording may not have started — that's fine
   }
@@ -21,16 +21,16 @@ export function stopRecording(): void {
 /**
  * Take a screenshot and save to the given path.
  */
-export function takeScreenshot(outputPath: string, fullPage = true): void {
+export function takeScreenshot(outputPath: string, fullPage = true, sessionName?: string): void {
   const fullFlag = fullPage ? ' --full' : '';
-  ab(`screenshot ${outputPath}${fullFlag}`, 15000);
+  ab(`screenshot ${outputPath}${fullFlag}`, { timeoutMs: 15000, session: sessionName });
 }
 
 /**
  * Take an annotated screenshot (labels interactive elements).
  */
-export function takeAnnotatedScreenshot(outputPath: string): void {
-  ab(`screenshot ${outputPath} --annotate`, 15000);
+export function takeAnnotatedScreenshot(outputPath: string, sessionName?: string): void {
+  ab(`screenshot ${outputPath} --annotate`, { timeoutMs: 15000, session: sessionName });
 }
 
 /**
@@ -41,9 +41,13 @@ export function diffScreenshots(
   baseline: string,
   current: string,
   outputPath: string,
+  sessionName?: string,
 ): number | null {
   try {
-    const result = ab(`diff screenshot ${baseline} ${current} ${outputPath}`, 15000);
+    const result = ab(`diff screenshot ${baseline} ${current} ${outputPath}`, {
+      timeoutMs: 15000,
+      session: sessionName,
+    });
     // Parse mismatch percentage from output
     const match = result.match(/([\d.]+)%/);
     return match ? parseFloat(match[1]) : null;

--- a/src/browser/interact.ts
+++ b/src/browser/interact.ts
@@ -3,34 +3,34 @@ import { ab } from '../utils/exec.js';
 /**
  * Click an element by its ref (e.g., @e3).
  */
-export function click(ref: string): void {
-  ab(`click ${ref}`, 10000);
+export function click(ref: string, sessionName?: string): void {
+  ab(`click ${ref}`, { timeoutMs: 10000, session: sessionName });
 }
 
 /**
  * Fill a form field by its ref.
  */
-export function fill(ref: string, value: string): void {
-  ab(`fill ${ref} "${value.replace(/"/g, '\\"')}"`, 10000);
+export function fill(ref: string, value: string, sessionName?: string): void {
+  ab(`fill ${ref} "${value.replace(/"/g, '\\"')}"`, { timeoutMs: 10000, session: sessionName });
 }
 
 /**
  * Type text (keyboard input, not targeting a specific element).
  */
-export function type(text: string): void {
-  ab(`type "${text.replace(/"/g, '\\"')}"`, 10000);
+export function type(text: string, sessionName?: string): void {
+  ab(`type "${text.replace(/"/g, '\\"')}"`, { timeoutMs: 10000, session: sessionName });
 }
 
 /**
  * Press a key (e.g., Enter, Tab, Escape).
  */
-export function press(key: string): void {
-  ab(`press ${key}`, 5000);
+export function press(key: string, sessionName?: string): void {
+  ab(`press ${key}`, { timeoutMs: 5000, session: sessionName });
 }
 
 /**
  * Scroll the page in a direction.
  */
-export function scroll(direction: 'up' | 'down' = 'down', amount = 3): void {
-  ab(`scroll ${direction} ${amount}`, 5000);
+export function scroll(direction: 'up' | 'down' = 'down', amount = 3, sessionName?: string): void {
+  ab(`scroll ${direction} ${amount}`, { timeoutMs: 5000, session: sessionName });
 }

--- a/src/browser/navigate.ts
+++ b/src/browser/navigate.ts
@@ -3,10 +3,10 @@ import { ab } from '../utils/exec.js';
 /**
  * Navigate to a URL and wait for the page to load.
  */
-export function navigateTo(url: string): void {
-  ab(`open ${url}`, 60000);
+export function navigateTo(url: string, sessionName?: string): void {
+  ab(`open ${url}`, { timeoutMs: 60000, session: sessionName });
   try {
-    ab('wait --load networkidle', 30000);
+    ab('wait --load networkidle', { timeoutMs: 30000, session: sessionName });
   } catch {
     // networkidle may timeout on some pages — that's okay,
     // we still have the page in whatever state it loaded to
@@ -17,9 +17,9 @@ export function navigateTo(url: string): void {
  * Get a snapshot of the page's interactive elements.
  * Returns the accessibility tree with element refs (@e1, @e2, etc).
  */
-export function getSnapshot(): string {
+export function getSnapshot(sessionName?: string): string {
   try {
-    return ab('snapshot -i', 15000);
+    return ab('snapshot -i', { timeoutMs: 15000, session: sessionName });
   } catch {
     return '';
   }

--- a/src/browser/session.ts
+++ b/src/browser/session.ts
@@ -9,18 +9,19 @@ export function openBrowser(
   url: string,
   viewport: ViewportConfig,
   headless = true,
+  sessionName?: string,
 ): void {
   const headlessFlag = headless ? '' : ' --headed';
-  ab(`open ${url}${headlessFlag}`, 60000);
-  ab(`set viewport ${viewport.width} ${viewport.height}`);
+  ab(`open ${url}${headlessFlag}`, { timeoutMs: 60000, session: sessionName });
+  ab(`set viewport ${viewport.width} ${viewport.height}`, { session: sessionName });
 }
 
 /**
  * Close the browser session.
  */
-export function closeBrowser(): void {
+export function closeBrowser(sessionName?: string): void {
   try {
-    ab('close');
+    ab('close', { session: sessionName });
   } catch {
     // Browser may already be closed — that's fine
   }
@@ -41,9 +42,9 @@ export function checkAgentBrowser(): boolean {
 /**
  * Get any console errors from the current page.
  */
-export function getConsoleErrors(): string {
+export function getConsoleErrors(sessionName?: string): string {
   try {
-    return ab('errors');
+    return ab('errors', { session: sessionName });
   } catch {
     return '';
   }
@@ -52,9 +53,9 @@ export function getConsoleErrors(): string {
 /**
  * Get console output from the current page.
  */
-export function getConsoleOutput(): string {
+export function getConsoleOutput(sessionName?: string): string {
   try {
-    return ab('console');
+    return ab('console', { session: sessionName });
   } catch {
     return '';
   }
@@ -69,9 +70,9 @@ export interface ConsoleMessage {
 /**
  * Get console output as structured JSON with per-message timestamps.
  */
-export function getConsoleOutputJson(): ConsoleMessage[] {
+export function getConsoleOutputJson(sessionName?: string): ConsoleMessage[] {
   try {
-    const raw = ab('console --json');
+    const raw = ab('console --json', { session: sessionName });
     const parsed = JSON.parse(raw);
     // agent-browser wraps JSON output: {success, data: {messages: [...]}, error}
     const messages = parsed?.data?.messages ?? parsed;
@@ -84,9 +85,9 @@ export function getConsoleOutputJson(): ConsoleMessage[] {
 /**
  * Get the current page title.
  */
-export function getPageTitle(): string {
+export function getPageTitle(sessionName?: string): string {
   try {
-    return ab('get title');
+    return ab('get title', { session: sessionName });
   } catch {
     return '';
   }
@@ -95,9 +96,9 @@ export function getPageTitle(): string {
 /**
  * Get the current page URL.
  */
-export function getPageUrl(): string {
+export function getPageUrl(sessionName?: string): string {
   try {
-    return ab('get url');
+    return ab('get url', { session: sessionName });
   } catch {
     return '';
   }

--- a/src/commands/exec.test.ts
+++ b/src/commands/exec.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildShellCommand } from './exec.js';
+
+describe('buildShellCommand', () => {
+  it('routes regular commands through the active ProofShot session', () => {
+    expect(buildShellCommand(['click', '@e2'], 'proofshot-2026-04-07_22-30-00')).toBe(
+      "agent-browser --session 'proofshot-2026-04-07_22-30-00' click @e2",
+    );
+  });
+
+  it('preserves eval shell quoting while adding the session flag', () => {
+    expect(buildShellCommand(['eval', "console.log('hello')"], 'proofshot-dev')).toBe(
+      "agent-browser --session 'proofshot-dev' eval 'console.log('\\''hello'\\'')'",
+    );
+  });
+
+  it('quotes regular arguments that contain shell metacharacters', () => {
+    expect(buildShellCommand(['screenshot', 'step (1).png'], 'proofshot-dev')).toBe(
+      "agent-browser --session 'proofshot-dev' screenshot 'step (1).png'",
+    );
+  });
+});

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { loadConfig } from '../utils/config.js';
-import { ab } from '../utils/exec.js';
+import { ab, buildAgentBrowserCommand } from '../utils/exec.js';
 import { loadSession, saveSession, type SessionState } from '../session/state.js';
 
 const SESSION_LOG_FILENAME = 'session-log.json';
@@ -54,13 +54,13 @@ function resolveScreenshotPath(args: string[], sessionDir: string): string[] {
  * to prevent the shell from interpreting parentheses, brackets, etc.
  * For other commands, simple joining is fine.
  */
-function buildShellCommand(args: string[]): string {
+export function buildShellCommand(args: string[], sessionName?: string): string {
   if (args[0] === 'eval' && args.length > 1) {
     // Join everything after 'eval' as the JS code, wrap in single quotes
     const jsCode = args.slice(1).join(' ');
     // Escape any single quotes in the JS code for shell safety
     const escaped = jsCode.replace(/'/g, "'\\''");
-    return `agent-browser eval '${escaped}'`;
+    return buildAgentBrowserCommand(`eval '${escaped}'`, { session: sessionName });
   }
 
   // For all other commands, quote each arg that contains shell-special chars
@@ -71,7 +71,7 @@ function buildShellCommand(args: string[]): string {
     }
     return arg;
   });
-  return `agent-browser ${quotedArgs.join(' ')}`;
+  return buildAgentBrowserCommand(quotedArgs.join(' '), { session: sessionName });
 }
 
 /**
@@ -99,6 +99,7 @@ function parseElementRef(args: string[]): string | null {
 function captureElementData(
   ref: string,
   viewport: { width: number; height: number },
+  sessionName?: string,
 ): SessionLogEntry['element'] | null {
   try {
     let bbox: { x: number; y: number; width: number; height: number } | null = null;
@@ -106,38 +107,41 @@ function captureElementData(
 
     // Strategy 1: Try id-based selector (works for inputs with id attributes)
     let elemId = '';
-    try { elemId = ab(`get attr ${ref} id`); } catch { /* empty */ }
+    try { elemId = ab(`get attr ${ref} id`, { session: sessionName }); } catch { /* empty */ }
 
     if (elemId) {
       try {
-        const raw = ab(`get box '#${elemId}'`);
+        const raw = ab(`get box '#${elemId}'`, { session: sessionName });
         bbox = JSON.parse(raw);
       } catch { /* empty */ }
 
       // For inputs, get label from associated <label> via eval (doesn't invalidate refs)
       try {
-        const raw = ab(`eval "document.getElementById('${elemId}')?.labels?.[0]?.textContent||document.getElementById('${elemId}')?.placeholder||document.getElementById('${elemId}')?.getAttribute('aria-label')||''"`);
+        const raw = ab(
+          `eval "document.getElementById('${elemId}')?.labels?.[0]?.textContent||document.getElementById('${elemId}')?.placeholder||document.getElementById('${elemId}')?.getAttribute('aria-label')||''"`,
+          { session: sessionName },
+        );
         label = JSON.parse(raw) || '';
       } catch { /* empty */ }
     }
 
     // Strategy 2: Try text-based selector (works for links, buttons)
     if (!bbox) {
-      try { label = ab(`get text ${ref}`); } catch { /* empty */ }
+      try { label = ab(`get text ${ref}`, { session: sessionName }); } catch { /* empty */ }
       if (!label) {
-        try { label = ab(`get attr ${ref} placeholder`); } catch { /* empty */ }
+        try { label = ab(`get attr ${ref} placeholder`, { session: sessionName }); } catch { /* empty */ }
       }
       if (!label) {
-        try { label = ab(`get attr ${ref} aria-label`); } catch { /* empty */ }
+        try { label = ab(`get attr ${ref} aria-label`, { session: sessionName }); } catch { /* empty */ }
       }
       if (!label) {
-        try { label = ab(`get attr ${ref} name`); } catch { /* empty */ }
+        try { label = ab(`get attr ${ref} name`, { session: sessionName }); } catch { /* empty */ }
       }
 
       if (label) {
         try {
           const escaped = label.replace(/'/g, "\\'");
-          const raw = ab(`get box 'text=${escaped}'`);
+          const raw = ab(`get box 'text=${escaped}'`, { session: sessionName });
           bbox = JSON.parse(raw);
         } catch { /* empty */ }
       }
@@ -201,7 +205,7 @@ export async function execCommand(args: string[]): Promise<void> {
   if (session && isRefTargetedAction(args)) {
     const ref = parseElementRef(args)!;
     const viewport = session.viewport || { width: 1280, height: 720 };
-    const captured = captureElementData(ref, viewport);
+    const captured = captureElementData(ref, viewport, session.sessionName);
     if (captured) elementData = captured;
   }
 
@@ -227,7 +231,7 @@ export async function execCommand(args: string[]): Promise<void> {
   }
 
   // Build shell command with proper quoting
-  const shellCmd = buildShellCommand(resolvedArgs);
+  const shellCmd = buildShellCommand(resolvedArgs, session?.sessionName);
 
   // Pass through to agent-browser
   try {
@@ -255,7 +259,9 @@ export async function execCommand(args: string[]): Promise<void> {
   // If the action was `set viewport`, update cached viewport in session state
   if (session && args[0] === 'set' && args[1] === 'viewport') {
     try {
-      const vpJson = ab("eval 'JSON.stringify({width: window.innerWidth, height: window.innerHeight})'");
+      const vpJson = ab("eval 'JSON.stringify({width: window.innerWidth, height: window.innerHeight})'", {
+        session: session.sessionName,
+      });
       const vp = JSON.parse(vpJson);
       session.viewport = { width: vp.width, height: vp.height };
       saveSession(session);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -6,7 +6,12 @@ import { ensureDevServer } from '../server/start.js';
 import { openBrowser } from '../browser/session.js';
 import { startRecording } from '../browser/capture.js';
 import { ensureOutputDir, generateTimestamp, generateSessionDirName } from '../artifacts/bundle.js';
-import { saveSession, hasActiveSession, clearSession } from '../session/state.js';
+import {
+  saveSession,
+  hasActiveSession,
+  clearSession,
+  generateAgentBrowserSessionName,
+} from '../session/state.js';
 import { writeMetadata } from '../session/metadata.js';
 
 interface StartOptions {
@@ -44,6 +49,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   const sessionDirName = generateSessionDirName(timestamp, options.description || null);
   const sessionDir = path.join(outputDir, sessionDirName);
+  const sessionName = generateAgentBrowserSessionName(timestamp);
   ensureOutputDir(sessionDir);
 
   const videoPath = path.join(sessionDir, `session.webm`);
@@ -104,7 +110,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   console.log(chalk.dim('Opening browser...'));
   try {
-    openBrowser(openUrl, config.viewport, config.headless);
+    openBrowser(openUrl, config.viewport, config.headless, sessionName);
     console.log(chalk.green('✓') + ' Browser ready');
   } catch (error: any) {
     console.error(
@@ -123,7 +129,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   for (let attempt = 1; attempt <= RECORDING_RETRIES; attempt++) {
     try {
-      startRecording(videoPath);
+      startRecording(videoPath, sessionName);
       recordingStarted = true;
       console.log(chalk.green('✓') + ' Recording started');
       break;
@@ -157,6 +163,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
     description: options.description || null,
     outputDir,
     sessionDir,
+    sessionName,
     videoPath,
     serverErrorLog,
     port: config.devServer.port,
@@ -171,6 +178,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
   console.log('');
   console.log(`Server:     ${options.run ? chalk.cyan(options.run) : chalk.dim('external')} on :${config.devServer.port}`);
   console.log(`Browser:    Chromium (${config.headless ? 'headless' : 'headed'})`);
+  console.log(`Session:    ${chalk.dim(sessionName)}`);
   console.log(`Recording:  ${chalk.dim(videoPath)}`);
   console.log(`Errors log: ${chalk.dim(serverErrorLog)}`);
 

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -77,10 +77,10 @@ export async function stopCommand(options: StopOptions): Promise<void> {
   let consoleOutput = '';
   let consoleEntries: TimestampedLogEntry[] = [];
   try {
-    consoleErrors = getConsoleErrors();
-    consoleOutput = getConsoleOutput();
+    consoleErrors = getConsoleErrors(session.sessionName);
+    consoleOutput = getConsoleOutput(session.sessionName);
     // Get timestamped console messages for viewer sync
-    const consoleMessages = getConsoleOutputJson();
+    const consoleMessages = getConsoleOutputJson(session.sessionName);
     consoleEntries = consoleMessages.map((msg) => ({
       text: `[${msg.type}] ${msg.text}`,
       relativeTimeSec: Math.max(0, parseFloat(((msg.timestamp - startTime) / 1000).toFixed(1))),
@@ -96,12 +96,12 @@ export async function stopCommand(options: StopOptions): Promise<void> {
 
   // Step 2: Stop recording
   console.log(chalk.dim('Stopping recording...'));
-  stopRecording();
+  stopRecording(session.sessionName);
 
   // Step 3: Close browser (unless --no-close)
   if (!options.noClose) {
     console.log(chalk.dim('Closing browser...'));
-    closeBrowser();
+    closeBrowser(session.sessionName);
   }
 
   // Step 4: Read server log (with timestamp parsing)

--- a/src/session/state.test.ts
+++ b/src/session/state.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { generateAgentBrowserSessionName } from './state.js';
+
+describe('generateAgentBrowserSessionName', () => {
+  it('prefixes ProofShot session names consistently', () => {
+    expect(generateAgentBrowserSessionName('2026-04-07_22-30-00')).toBe(
+      'proofshot-2026-04-07_22-30-00',
+    );
+  });
+
+  it('normalizes unsafe characters', () => {
+    expect(generateAgentBrowserSessionName("April 7 review / O'Connor")).toBe(
+      'proofshot-april-7-review-o-connor',
+    );
+  });
+});

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -8,6 +8,7 @@ export interface SessionState {
   description: string | null;
   outputDir: string;
   sessionDir: string;
+  sessionName: string;
   videoPath: string;
   serverErrorLog: string;
   port: number;
@@ -54,4 +55,17 @@ export function clearSession(outputDir: string): void {
   if (fs.existsSync(sessionPath)) {
     fs.unlinkSync(sessionPath);
   }
+}
+
+/**
+ * Generate a deterministic agent-browser session name for a ProofShot run.
+ */
+export function generateAgentBrowserSessionName(seed: string): string {
+  const normalized = seed
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+  return normalized ? `proofshot-${normalized}` : 'proofshot';
 }

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildAgentBrowserCommand } from './exec.js';
+
+describe('buildAgentBrowserCommand', () => {
+  it('builds a plain agent-browser command when no session is provided', () => {
+    expect(buildAgentBrowserCommand('open http://localhost:3000')).toBe(
+      'agent-browser open http://localhost:3000',
+    );
+  });
+
+  it('prepends the configured session flag before the command', () => {
+    expect(buildAgentBrowserCommand('snapshot -i', { session: 'proofshot-2026-04-07_22-30-00' })).toBe(
+      "agent-browser --session 'proofshot-2026-04-07_22-30-00' snapshot -i",
+    );
+  });
+
+  it('shell-quotes session names safely', () => {
+    expect(buildAgentBrowserCommand('console', { session: "proofshot-o'connor" })).toBe(
+      "agent-browser --session 'proofshot-o'\\''connor' console",
+    );
+  });
+});

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -11,16 +11,42 @@ export class ProofShotError extends Error {
   }
 }
 
+export interface AgentBrowserCommandOptions {
+  session?: string;
+  timeoutMs?: number;
+}
+
+function shellQuote(value: string): string {
+  const escaped = value.replace(/'/g, "'\\''");
+  return `'${escaped}'`;
+}
+
+export function buildAgentBrowserCommand(
+  command: string,
+  options: Pick<AgentBrowserCommandOptions, 'session'> = {},
+): string {
+  const sessionFlag = options.session ? ` --session ${shellQuote(options.session)}` : '';
+  return `agent-browser${sessionFlag} ${command}`;
+}
+
 /**
  * Execute an agent-browser command via CLI.
  * agent-browser uses a Rust CLI + persistent Node.js daemon architecture,
  * so calling it via CLI is the intended usage pattern.
  */
-export function ab(command: string, timeoutMs = 30000): string {
+export function ab(
+  command: string,
+  timeoutOrOptions: number | AgentBrowserCommandOptions = 30000,
+): string {
+  const options =
+    typeof timeoutOrOptions === 'number'
+      ? { timeoutMs: timeoutOrOptions }
+      : timeoutOrOptions;
+
   try {
-    return execSync(`agent-browser ${command}`, {
+    return execSync(buildAgentBrowserCommand(command, options), {
       encoding: 'utf-8',
-      timeout: timeoutMs,
+      timeout: options.timeoutMs ?? 30000,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- generate and persist a dedicated `agent-browser` session name for each ProofShot run
- route all browser-facing `start`, `exec`, and `stop` commands through that same session
- add focused tests for session-aware command construction and session-name generation
- document that `proofshot exec` reuses the browser session created by `proofshot start`

## Problem
ProofShot relies on a sequence of separate `agent-browser` CLI calls across a single verification run.

Before this change, those calls did not explicitly opt into a shared `agent-browser` session. That made ProofShot dependent on whichever default session state the daemon happened to use, which can reduce reliability when the workflow expects:
- the browser opened by `proofshot start`
- the recording started for that run
- later `proofshot exec` actions
- screenshot capture
- console/error collection during `proofshot stop`

to all target the same browser session.

## Solution
This change gives each ProofShot run its own deterministic session name, stores it in ProofShot session state, and passes it through every `agent-browser` invocation that belongs to that run.

That keeps the session boundary explicit instead of implicit, and makes the browser lifecycle easier to reason about in later fixes around recording and screenshot reliability.

## Testing
- `npm test`
- `npm run build`
