### PR TITLE
fix: clean up failed startup sessions

### DIFF
--- a/src/commands/start.test.ts
+++ b/src/commands/start.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { startCommand } from './start.js';
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  ensureDevServer: vi.fn(),
+  openBrowser: vi.fn(),
+  closeBrowser: vi.fn(),
+  startRecording: vi.fn(),
+  ensureOutputDir: vi.fn(),
+  generateTimestamp: vi.fn(),
+  generateSessionDirName: vi.fn(),
+  saveSession: vi.fn(),
+  hasActiveSession: vi.fn(),
+  clearSession: vi.fn(),
+  generateAgentBrowserSessionName: vi.fn(),
+  writeMetadata: vi.fn(),
+  execSync: vi.fn(),
+}));
+
+vi.mock('../utils/config.js', () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock('../server/start.js', () => ({
+  ensureDevServer: mocks.ensureDevServer,
+}));
+
+vi.mock('../browser/session.js', () => ({
+  openBrowser: mocks.openBrowser,
+  closeBrowser: mocks.closeBrowser,
+}));
+
+vi.mock('../browser/capture.js', () => ({
+  startRecording: mocks.startRecording,
+}));
+
+vi.mock('../artifacts/bundle.js', () => ({
+  ensureOutputDir: mocks.ensureOutputDir,
+  generateTimestamp: mocks.generateTimestamp,
+  generateSessionDirName: mocks.generateSessionDirName,
+}));
+
+vi.mock('../session/state.js', () => ({
+  saveSession: mocks.saveSession,
+  hasActiveSession: mocks.hasActiveSession,
+  clearSession: mocks.clearSession,
+  generateAgentBrowserSessionName: mocks.generateAgentBrowserSessionName,
+}));
+
+vi.mock('../session/metadata.js', () => ({
+  writeMetadata: mocks.writeMetadata,
+}));
+
+vi.mock('child_process', () => ({
+  execSync: mocks.execSync,
+}));
+
+describe('startCommand', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as never);
+
+    mocks.loadConfig.mockReturnValue({
+      output: './proofshot-artifacts',
+      headless: true,
+      viewport: { width: 1280, height: 720 },
+      devServer: {
+        port: 3000,
+        startupTimeout: 1000,
+      },
+    });
+    mocks.hasActiveSession.mockReturnValue(false);
+    mocks.generateTimestamp.mockReturnValue('2026-04-08_07-28-00');
+    mocks.generateSessionDirName.mockReturnValue('2026-04-08_07-28-00_test');
+    mocks.generateAgentBrowserSessionName.mockReturnValue('proofshot-2026-04-08_07-28-00');
+    mocks.execSync.mockImplementation((command: string) => {
+      if (command === 'git branch --show-current') return 'main';
+      if (command === 'git rev-parse HEAD') return 'deadbeef';
+      throw new Error(`unexpected command: ${command}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.values(mocks).forEach((mock) => mock.mockReset());
+  });
+
+  it('closes the browser when recording never starts after all retries', async () => {
+    mocks.startRecording.mockImplementation(() => {
+      throw new Error('Recording session could not be initialized');
+    });
+
+    const commandPromise = startCommand({}).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(commandPromise).resolves.toMatchObject({ message: 'process.exit:1' });
+    expect(mocks.startRecording).toHaveBeenCalledTimes(3);
+    expect(mocks.closeBrowser).toHaveBeenCalledTimes(1);
+    expect(mocks.saveSession).not.toHaveBeenCalled();
+  });
+
+  it('does not try to stop recording when recording never started', async () => {
+    mocks.startRecording.mockImplementation(() => {
+      throw new Error('Recording already active');
+    });
+
+    const commandPromise = startCommand({}).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(commandPromise).resolves.toMatchObject({ message: 'process.exit:1' });
+    expect(mocks.startRecording).toHaveBeenCalledTimes(3);
+    expect(mocks.closeBrowser).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the session-scoped browser when browser open fails', async () => {
+    mocks.openBrowser.mockImplementation(() => {
+      throw new Error('Chrome exited early without writing DevToolsActivePort');
+    });
+
+    const commandPromise = startCommand({}).catch((error) => error);
+
+    await expect(commandPromise).resolves.toMatchObject({ message: 'process.exit:1' });
+    expect(mocks.closeBrowser).toHaveBeenCalledTimes(1);
+    expect(mocks.startRecording).not.toHaveBeenCalled();
+    expect(mocks.saveSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { execSync } from 'child_process';
 import { loadConfig } from '../utils/config.js';
 import { ensureDevServer } from '../server/start.js';
-import { openBrowser } from '../browser/session.js';
+import { closeBrowser, openBrowser } from '../browser/session.js';
 import { startRecording } from '../browser/capture.js';
 import { ensureOutputDir, generateTimestamp, generateSessionDirName } from '../artifacts/bundle.js';
 import { saveSession, hasActiveSession, clearSession } from '../session/state.js';
@@ -16,6 +16,7 @@ interface StartOptions {
   headed?: boolean;
   output?: string;
   url?: string;
+  force?: boolean;
 }
 
 export async function startCommand(options: StartOptions): Promise<void> {
@@ -46,10 +47,9 @@ export async function startCommand(options: StartOptions): Promise<void> {
   const sessionDir = path.join(outputDir, sessionDirName);
   ensureOutputDir(sessionDir);
 
-  const videoPath = path.join(sessionDir, `session.webm`);
+  const videoPath = path.join(sessionDir, 'session.webm');
   const serverErrorLog = path.join(sessionDir, 'server.log');
 
-  // Capture git metadata for branch-based PR matching
   let branch = '';
   let commitSha = '';
   try {
@@ -58,7 +58,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch {
-    // Not in a git repo or git not available — non-fatal
+    // Non-fatal outside a git repo.
   }
   try {
     commitSha = execSync('git rev-parse HEAD', {
@@ -66,10 +66,9 @@ export async function startCommand(options: StartOptions): Promise<void> {
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch {
-    // Non-fatal
+    // Non-fatal outside a git repo.
   }
 
-  // Write persistent metadata (survives proofshot stop)
   writeMetadata(sessionDir, {
     branch,
     commitSha,
@@ -107,6 +106,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
     openBrowser(openUrl, config.viewport, config.headless);
     console.log(chalk.green('✓') + ' Browser ready');
   } catch (error: any) {
+    closeBrowser();
     console.error(
       chalk.red('✗') +
         ` Failed to open browser: ${error.message}\n` +
@@ -115,7 +115,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
     process.exit(1);
   }
 
-  // Recording is mandatory — retry up to 3 times for transient failures (browser not ready, etc.)
   const RECORDING_RETRIES = 3;
   const RETRY_DELAY_MS = 2000;
   let recordingStarted = false;
@@ -140,9 +139,10 @@ export async function startCommand(options: StartOptions): Promise<void> {
   }
 
   if (!recordingStarted) {
+    closeBrowser();
     console.error(
       chalk.red('✗') +
-        ` Failed to start recording after ${RECORDING_RETRIES} attempts: ${lastError?.message}\n` +
+        ` Failed to initialize recording after ${RECORDING_RETRIES} attempts: ${lastError?.message}\n` +
         chalk.dim('Recording is required — ProofShot cannot proceed without video capture.\n') +
         chalk.dim('Troubleshooting:\n') +
         chalk.dim('  1. Make sure agent-browser is installed and running\n') +


### PR DESCRIPTION
## Summary
- close the browser when `proofshot start` fails during the browser-open step
- close the browser when `proofshot start` exhausts recording-start retries without creating an active session
- add focused regression tests for both failure paths

## Problem
ProofShot could leak browser windows during startup failures.

Two separate paths were affected:
- if `agent-browser open` partially launched Chrome and then failed, `proofshot start` exited without cleaning up the browser
- if recording never started successfully after all retries, the startup flow exited and left the opened browser behind

That was especially visible during repeated local debugging, where failed starts accumulated blank or half-initialized browser windows.

## Solution
This change adds best-effort browser cleanup to both startup failure paths:
- browser-open failure
- final recording-start failure after all retries

## Testing
- `npm test`
- `npm run build`
