### PR TITLE
feat: make browser launch config project-specific

### DIFF
--- a/PROOFSHOT.md
+++ b/PROOFSHOT.md
@@ -18,3 +18,6 @@ Key proofshot exec commands:
 - `proofshot exec screenshot step.png` — capture a moment
 
 Artifacts saved to ./proofshot-artifacts/ including video, screenshots, errors, and summary.
+
+Use `proofshot doctor` when the local setup looks wrong. It prints the current config path, browser mode, viewport, installed binaries, and any active ProofShot session.
+You can customize browser launch behavior in `proofshot.config.json`, including HTTPS error ignoring and a custom browser executable path.

--- a/PROOFSHOT.md
+++ b/PROOFSHOT.md
@@ -18,6 +18,5 @@ Key proofshot exec commands:
 - `proofshot exec screenshot step.png` — capture a moment
 
 Artifacts saved to ./proofshot-artifacts/ including video, screenshots, errors, and summary.
-
-Use `proofshot doctor` when the local setup looks wrong. It prints the current config path, browser mode, viewport, installed binaries, and any active ProofShot session.
 You can customize browser launch behavior in `proofshot.config.json`, including HTTPS error ignoring and a custom browser executable path.
+You can customize browser launch behavior in `proofshot.config.json`, including HTTPS error ignoring, a custom browser executable path, and a project-specific `agent-browser` config path.

--- a/PROOFSHOT.md
+++ b/PROOFSHOT.md
@@ -18,5 +18,4 @@ Key proofshot exec commands:
 - `proofshot exec screenshot step.png` — capture a moment
 
 Artifacts saved to ./proofshot-artifacts/ including video, screenshots, errors, and summary.
-You can customize browser launch behavior in `proofshot.config.json`, including HTTPS error ignoring and a custom browser executable path.
 You can customize browser launch behavior in `proofshot.config.json`, including HTTPS error ignoring, a custom browser executable path, and a project-specific `agent-browser` config path.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ proofshot start --headed                                # Show browser (debuggin
 proofshot start --force                                 # Override a stale session from a previous crash
 ```
 
+You can also configure browser launch behavior in `proofshot.config.json`:
+
+```json
+{
+  "browser": {
+    "ignoreHttpsErrors": true,
+    "executablePath": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  }
+}
+```
+
 ### `proofshot stop`
 
 Stop recording, collect errors, generate proof artifacts.

--- a/README.md
+++ b/README.md
@@ -149,12 +149,14 @@ You can also configure browser launch behavior in `proofshot.config.json`:
 ```json
 {
   "browser": {
+    "configPath": "./agent-browser.local.json",
     "ignoreHttpsErrors": true,
     "executablePath": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
   }
 }
 ```
 
+Set `browser.configPath` when you need ProofShot to run `agent-browser` against a project-specific config instead of inheriting `~/.agent-browser/config.json`. Relative paths are resolved from the directory that contains `proofshot.config.json`.
 ### `proofshot stop`
 
 Stop recording, collect errors, generate proof artifacts.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ You can also configure browser launch behavior in `proofshot.config.json`:
 ```
 
 Set `browser.configPath` when you need ProofShot to run `agent-browser` against a project-specific config instead of inheriting `~/.agent-browser/config.json`. Relative paths are resolved from the directory that contains `proofshot.config.json`.
+
 ### `proofshot stop`
 
 Stop recording, collect errors, generate proof artifacts.

--- a/src/browser/session.test.ts
+++ b/src/browser/session.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenBrowserCommand } from './session.js';
+
+describe('buildOpenBrowserCommand', () => {
+  it('builds a default open command without extra flags', () => {
+    expect(buildOpenBrowserCommand('http://localhost:3000')).toBe('open http://localhost:3000');
+  });
+
+  it('includes headed mode when headless is disabled', () => {
+    expect(buildOpenBrowserCommand('http://localhost:3000', false)).toBe(
+      'open http://localhost:3000 --headed',
+    );
+  });
+
+  it('includes configurable browser flags from ProofShot config', () => {
+    expect(
+      buildOpenBrowserCommand('https://localhost:3000', true, {
+        ignoreHttpsErrors: true,
+        executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      }),
+    ).toBe(
+      'open https://localhost:3000 --ignore-https-errors --executable-path "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"',
+    );
+  });
+});

--- a/src/browser/session.ts
+++ b/src/browser/session.ts
@@ -1,5 +1,20 @@
 import { ab, ProofShotError } from '../utils/exec.js';
-import type { ViewportConfig } from '../utils/config.js';
+import type { BrowserConfig, ViewportConfig } from '../utils/config.js';
+
+export function buildOpenBrowserCommand(
+  url: string,
+  headless = true,
+  browserConfig?: BrowserConfig,
+): string {
+  const flags: string[] = [];
+
+  if (!headless) flags.push('--headed');
+  if (browserConfig?.ignoreHttpsErrors) flags.push('--ignore-https-errors');
+  if (browserConfig?.executablePath) flags.push(`--executable-path "${browserConfig.executablePath.replace(/"/g, '\\"')}"`);
+
+  const suffix = flags.length > 0 ? ` ${flags.join(' ')}` : '';
+  return `open ${url}${suffix}`;
+}
 
 /**
  * Initialize a browser session.
@@ -10,9 +25,9 @@ export function openBrowser(
   viewport: ViewportConfig,
   headless = true,
   sessionName?: string,
+  browserConfig?: BrowserConfig,
 ): void {
-  const headlessFlag = headless ? '' : ' --headed';
-  ab(`open ${url}${headlessFlag}`, { timeoutMs: 60000, session: sessionName });
+  ab(buildOpenBrowserCommand(url, headless, browserConfig), { timeoutMs: 60000, session: sessionName });
   ab(`set viewport ${viewport.width} ${viewport.height}`, { session: sessionName });
 }
 

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { loadConfig } from '../utils/config.js';
-import { ab, buildAgentBrowserCommand } from '../utils/exec.js';
+import { ab, buildAgentBrowserCommand, setAgentBrowserDefaults } from '../utils/exec.js';
 import { loadSession, saveSession, type SessionState } from '../session/state.js';
 
 const SESSION_LOG_FILENAME = 'session-log.json';
@@ -56,14 +56,11 @@ function resolveScreenshotPath(args: string[], sessionDir: string): string[] {
  */
 export function buildShellCommand(args: string[], sessionName?: string): string {
   if (args[0] === 'eval' && args.length > 1) {
-    // Join everything after 'eval' as the JS code, wrap in single quotes
     const jsCode = args.slice(1).join(' ');
-    // Escape any single quotes in the JS code for shell safety
     const escaped = jsCode.replace(/'/g, "'\\''");
     return buildAgentBrowserCommand(`eval '${escaped}'`, { session: sessionName });
   }
 
-  // For all other commands, quote each arg that contains shell-special chars
   const quotedArgs = args.map((arg) => {
     if (/[(){}[\]$`!#&|;<>*? "'\\]/.test(arg)) {
       const escaped = arg.replace(/'/g, "'\\''");
@@ -183,6 +180,7 @@ export async function execCommand(args: string[]): Promise<void> {
 
   // Load session state
   const config = loadConfig();
+  setAgentBrowserDefaults({ configPath: config.browser.configPath });
   const outputDir = path.resolve(config.output);
   const session = loadSession(outputDir);
 

--- a/src/commands/start.test.ts
+++ b/src/commands/start.test.ts
@@ -69,6 +69,7 @@ describe('startCommand', () => {
       output: './proofshot-artifacts',
       headless: true,
       viewport: { width: 1280, height: 720 },
+      browser: {},
       devServer: {
         port: 3000,
         startupTimeout: 1000,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
 import { loadConfig } from '../utils/config.js';
+import { setAgentBrowserDefaults } from '../utils/exec.js';
 import { ensureDevServer } from '../server/start.js';
 import { closeBrowser, openBrowser } from '../browser/session.js';
 import { startRecording } from '../browser/capture.js';
@@ -26,6 +27,7 @@ interface StartOptions {
 
 export async function startCommand(options: StartOptions): Promise<void> {
   const config = loadConfig();
+  setAgentBrowserDefaults({ configPath: config.browser.configPath });
   if (options.port) config.devServer.port = options.port;
   if (options.output) config.output = options.output;
   if (options.headed !== undefined) config.headless = !options.headed;
@@ -109,7 +111,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   console.log(chalk.dim('Opening browser...'));
   try {
-    openBrowser(openUrl, config.viewport, config.headless, sessionName);
+    openBrowser(openUrl, config.viewport, config.headless, sessionName, config.browser);
     console.log(chalk.green('✓') + ' Browser ready');
   } catch (error: any) {
     closeBrowser();

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
 import { loadConfig } from '../utils/config.js';
+import { setAgentBrowserDefaults } from '../utils/exec.js';
 import { closeBrowser, getConsoleErrors, getConsoleOutput, getConsoleOutputJson } from '../browser/session.js';
 import { stopRecording } from '../browser/capture.js';
 import { loadSession, clearSession } from '../session/state.js';
@@ -54,6 +55,7 @@ interface StopOptions {
 
 export async function stopCommand(options: StopOptions): Promise<void> {
   const config = loadConfig();
+  setAgentBrowserDefaults({ configPath: config.browser.configPath });
   const outputDir = path.resolve(config.output);
 
   // Load session state

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+import { loadConfig } from './config.js';
+
+describe('loadConfig', () => {
+  it('merges nested browser config with defaults', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proofshot-config-test-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'proofshot.config.json'),
+      JSON.stringify({
+        browser: {
+          executablePath: '/tmp/chrome',
+        },
+      }),
+    );
+
+    expect(loadConfig(tempDir).browser).toEqual({
+      executablePath: '/tmp/chrome',
+      ignoreHttpsErrors: false,
+    });
+  });
+});

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -17,7 +17,26 @@ describe('loadConfig', () => {
     );
 
     expect(loadConfig(tempDir).browser).toEqual({
+      configPath: undefined,
       executablePath: '/tmp/chrome',
+      ignoreHttpsErrors: false,
+    });
+  });
+
+  it('resolves browser config paths relative to proofshot.config.json', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proofshot-browser-config-path-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'proofshot.config.json'),
+      JSON.stringify({
+        browser: {
+          configPath: './agent-browser.local.json',
+        },
+      }),
+    );
+
+    expect(loadConfig(tempDir).browser).toEqual({
+      configPath: path.join(tempDir, 'agent-browser.local.json'),
+      executablePath: undefined,
       ignoreHttpsErrors: false,
     });
   });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -11,12 +11,18 @@ export interface ViewportConfig {
   height: number;
 }
 
+export interface BrowserConfig {
+  executablePath?: string;
+  ignoreHttpsErrors: boolean;
+}
+
 export interface ProofShotConfig {
   devServer: DevServerConfig;
   output: string;
   defaultPages: string[];
   viewport: ViewportConfig;
   headless: boolean;
+  browser: BrowserConfig;
 }
 
 const CONFIG_FILENAME = 'proofshot.config.json';
@@ -30,6 +36,9 @@ const DEFAULT_CONFIG: ProofShotConfig = {
   defaultPages: ['/'],
   viewport: { width: 1280, height: 720 },
   headless: true,
+  browser: {
+    ignoreHttpsErrors: false,
+  },
 };
 
 /**
@@ -61,6 +70,7 @@ export function loadConfig(startDir?: string): ProofShotConfig {
       ...parsed,
       devServer: { ...DEFAULT_CONFIG.devServer, ...parsed.devServer },
       viewport: { ...DEFAULT_CONFIG.viewport, ...parsed.viewport },
+      browser: { ...DEFAULT_CONFIG.browser, ...parsed.browser },
     };
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -12,6 +12,7 @@ export interface ViewportConfig {
 }
 
 export interface BrowserConfig {
+  configPath?: string;
   executablePath?: string;
   ignoreHttpsErrors: boolean;
 }
@@ -65,12 +66,20 @@ export function loadConfig(startDir?: string): ProofShotConfig {
   try {
     const raw = fs.readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw);
+    const configDir = path.dirname(configPath);
+    const resolvedBrowser = {
+      ...DEFAULT_CONFIG.browser,
+      ...parsed.browser,
+    };
+    if (resolvedBrowser.configPath) {
+      resolvedBrowser.configPath = path.resolve(configDir, resolvedBrowser.configPath);
+    }
     return {
       ...DEFAULT_CONFIG,
       ...parsed,
       devServer: { ...DEFAULT_CONFIG.devServer, ...parsed.devServer },
       viewport: { ...DEFAULT_CONFIG.viewport, ...parsed.viewport },
-      browser: { ...DEFAULT_CONFIG.browser, ...parsed.browser },
+      browser: resolvedBrowser,
     };
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { buildAgentBrowserCommand } from './exec.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildAgentBrowserCommand, setAgentBrowserDefaults } from './exec.js';
 
 describe('buildAgentBrowserCommand', () => {
-  it('builds a plain agent-browser command when no session is provided', () => {
+  afterEach(() => {
+    setAgentBrowserDefaults({});
+  });
+
+  it('builds a plain agent-browser command when no options are provided', () => {
     expect(buildAgentBrowserCommand('open http://localhost:3000')).toBe(
       'agent-browser open http://localhost:3000',
     );
@@ -17,6 +21,20 @@ describe('buildAgentBrowserCommand', () => {
   it('shell-quotes session names safely', () => {
     expect(buildAgentBrowserCommand('console', { session: "proofshot-o'connor" })).toBe(
       "agent-browser --session 'proofshot-o'\\''connor' console",
+    );
+  });
+
+  it('prepends the configured agent-browser config path before the command', () => {
+    expect(buildAgentBrowserCommand('open http://localhost:3000', { configPath: '/tmp/agent-browser.json' })).toBe(
+      "agent-browser --config '/tmp/agent-browser.json' open http://localhost:3000",
+    );
+  });
+
+  it('applies default config path options to later commands', () => {
+    setAgentBrowserDefaults({ configPath: '/tmp/project-agent-browser.json' });
+
+    expect(buildAgentBrowserCommand('snapshot -i')).toBe(
+      "agent-browser --config '/tmp/project-agent-browser.json' snapshot -i",
     );
   });
 });

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -12,8 +12,17 @@ export class ProofShotError extends Error {
 }
 
 export interface AgentBrowserCommandOptions {
+  configPath?: string;
   session?: string;
   timeoutMs?: number;
+}
+
+let defaultAgentBrowserOptions: Pick<AgentBrowserCommandOptions, 'configPath'> = {};
+
+export function setAgentBrowserDefaults(
+  options: Pick<AgentBrowserCommandOptions, 'configPath'>,
+): void {
+  defaultAgentBrowserOptions = { ...options };
 }
 
 function shellQuote(value: string): string {
@@ -23,10 +32,15 @@ function shellQuote(value: string): string {
 
 export function buildAgentBrowserCommand(
   command: string,
-  options: Pick<AgentBrowserCommandOptions, 'session'> = {},
+  options: Pick<AgentBrowserCommandOptions, 'configPath' | 'session'> = {},
 ): string {
-  const sessionFlag = options.session ? ` --session ${shellQuote(options.session)}` : '';
-  return `agent-browser${sessionFlag} ${command}`;
+  const mergedOptions = {
+    ...defaultAgentBrowserOptions,
+    ...options,
+  };
+  const configFlag = mergedOptions.configPath ? ` --config ${shellQuote(mergedOptions.configPath)}` : '';
+  const sessionFlag = mergedOptions.session ? ` --session ${shellQuote(mergedOptions.session)}` : '';
+  return `agent-browser${configFlag}${sessionFlag} ${command}`;
 }
 
 /**
@@ -42,9 +56,9 @@ export function ab(
     typeof timeoutOrOptions === 'number'
       ? { timeoutMs: timeoutOrOptions }
       : timeoutOrOptions;
-
+  const fullCommand = buildAgentBrowserCommand(command, options);
   try {
-    return execSync(buildAgentBrowserCommand(command, options), {
+    return execSync(fullCommand, {
       encoding: 'utf-8',
       timeout: options.timeoutMs ?? 30000,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -53,15 +67,12 @@ export function ab(
     const stderr = error?.stderr?.toString?.() || '';
     const message = stderr || error?.message || 'Unknown error';
     throw new ProofShotError(
-      `Browser command failed: agent-browser ${command}\n${message}`,
+      `Browser command failed: ${fullCommand}\n${message}`,
       error,
     );
   }
 }
 
-/**
- * Execute a shell command and return stdout.
- */
 export function exec(command: string, timeoutMs = 30000): string {
   try {
     return execSync(command, {
@@ -75,10 +86,6 @@ export function exec(command: string, timeoutMs = 30000): string {
   }
 }
 
-/**
- * Spawn a background process (detached, unreffed).
- * Used for starting dev servers that should outlive proofshot.
- */
 export function spawnBackground(
   command: string,
   cwd?: string,


### PR DESCRIPTION
## Summary
- add a nested `browser` config section to `proofshot.config.json`
- support `ignoreHttpsErrors` and `executablePath` when opening the browser
- add `browser.configPath` so ProofShot can pin all `agent-browser` commands to a project-specific config file
- resolve `browser.configPath` relative to the directory that contains `proofshot.config.json`
- apply that config path across `start`, `exec`, and `stop`

## Problem
ProofShot previously relied on ambient machine state for browser behavior.

Two gaps mattered in practice:
- common launch options like a custom browser executable or HTTPS-ignore behavior had no project-level config surface
- ProofShot inherited the user's default `~/.agent-browser/config.json`, so personal browser settings could leak into project verification runs

That made browser setup less reproducible across machines and projects.

## Solution
This change introduces one coherent browser configuration surface in `proofshot.config.json`:
- `browser.ignoreHttpsErrors`
- `browser.executablePath`
- `browser.configPath`

`browser.configPath` is resolved relative to `proofshot.config.json` and then applied to every `agent-browser` invocation used by the ProofShot session flow.

## Testing
- `npm test`
- `npm run build`

## Local verification
Using a sample app `browser.configPath` that points to a clean `agent-browser` config with Chrome for Testing, ProofShot stopped launching the user's global Helium browser and instead launched Chrome for Testing.
