### PR TITLE
feat: add a doctor command for local diagnostics

### DIFF
--- a/PROOFSHOT.md
+++ b/PROOFSHOT.md
@@ -16,3 +16,5 @@ Key proofshot exec commands:
 - `proofshot exec screenshot step.png` — capture a moment
 
 Artifacts saved to ./proofshot-artifacts/ including video, screenshots, errors, and summary.
+
+Use `proofshot doctor` when the local setup looks wrong. It prints the current config path, browser mode, viewport, installed binaries, and any active ProofShot session.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,14 @@ Remove the `./proofshot-artifacts/` directory.
 proofshot clean
 ```
 
+### `proofshot doctor`
+
+Print the current ProofShot environment, including config path, browser mode, viewport, installed binaries, and any active session.
+
+```bash
+proofshot doctor
+```
+
 ## Supported Agents
 
 `proofshot install` detects and configures skills for:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { diffCommand } from './commands/diff.js';
 import { cleanCommand } from './commands/clean.js';
 import { prCommand } from './commands/pr.js';
 import { execCommand } from './commands/exec.js';
+import { doctorCommand } from './commands/doctor.js';
 import { PROOFSHOT_VERSION } from './version.js';
 
 export function createCLI(): Command {
@@ -61,6 +62,13 @@ export function createCLI(): Command {
     .description('Remove artifact files')
     .action(async () => {
       await cleanCommand();
+    });
+
+  program
+    .command('doctor')
+    .description('Inspect the local ProofShot environment and active session state')
+    .action(async () => {
+      await doctorCommand();
     });
 
   program

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { findConfigPathMock, loadConfigMock, loadSessionMock, findExecutablePathMock, readCommandVersionMock } =
+  vi.hoisted(() => ({
+    findConfigPathMock: vi.fn(),
+    loadConfigMock: vi.fn(),
+    loadSessionMock: vi.fn(),
+    findExecutablePathMock: vi.fn(),
+    readCommandVersionMock: vi.fn(),
+  }));
+
+vi.mock('../utils/config.js', () => ({
+  findConfigPath: findConfigPathMock,
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../session/state.js', () => ({
+  loadSession: loadSessionMock,
+}));
+
+vi.mock('../utils/process.js', () => ({
+  findExecutablePath: findExecutablePathMock,
+  readCommandVersion: readCommandVersionMock,
+}));
+
+import { doctorCommand } from './doctor.js';
+
+describe('doctorCommand', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    findConfigPathMock.mockReturnValue('/tmp/proofshot.config.json');
+    loadConfigMock.mockReturnValue({
+      output: './proofshot-artifacts',
+      headless: true,
+      viewport: { width: 1280, height: 720 },
+      devServer: { port: 3000, startupTimeout: 30000 },
+      defaultPages: ['/'],
+    });
+    loadSessionMock.mockReturnValue(null);
+    findExecutablePathMock.mockImplementation((name: string) =>
+      name === 'agent-browser' ? '/usr/local/bin/agent-browser' : '/opt/homebrew/bin/ffmpeg',
+    );
+    readCommandVersionMock.mockImplementation((name: string) =>
+      name === 'agent-browser' ? 'agent-browser 0.25.3' : 'ffmpeg version 7.0',
+    );
+  });
+
+  it('prints a diagnostic summary for the current environment', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await doctorCommand();
+
+    const output = logSpy.mock.calls.map(([line]) => String(line)).join('\n');
+    expect(output).toContain('ProofShot Doctor');
+    expect(output).toContain('agent-browser');
+    expect(output).toContain('ffmpeg');
+    expect(output).toContain('1280x720');
+    expect(output).toContain('proofshot-artifacts');
+  });
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,54 @@
+import chalk from 'chalk';
+import { PROOFSHOT_VERSION } from '../version.js';
+import { findConfigPath, loadConfig } from '../utils/config.js';
+import { findExecutablePath, readCommandVersion } from '../utils/process.js';
+import { loadSession } from '../session/state.js';
+
+function statusLabel(ok: boolean, text: string): string {
+  return ok ? `${chalk.green('✓')} ${text}` : `${chalk.yellow('⚠')} ${text}`;
+}
+
+function printLine(label: string, value: string): void {
+  console.log(`${label.padEnd(14)} ${value}`);
+}
+
+export async function doctorCommand(): Promise<void> {
+  const configPath = findConfigPath();
+  const config = loadConfig();
+  const outputDir = config.output;
+  const session = loadSession(outputDir);
+
+  const agentBrowserPath = findExecutablePath('agent-browser');
+  const ffmpegPath = findExecutablePath('ffmpeg');
+  const agentBrowserVersion = readCommandVersion('agent-browser');
+  const ffmpegVersion = readCommandVersion('ffmpeg');
+
+  console.log(chalk.bold('ProofShot Doctor'));
+  console.log('');
+
+  printLine('ProofShot', PROOFSHOT_VERSION);
+  printLine('Config', configPath || chalk.dim('not found'));
+  printLine('Output', outputDir);
+  printLine('Browser mode', config.headless ? 'headless' : 'headed');
+  printLine('Viewport', `${config.viewport.width}x${config.viewport.height}`);
+  console.log('');
+
+  console.log(statusLabel(Boolean(agentBrowserPath), 'agent-browser'));
+  printLine('Path', agentBrowserPath || chalk.dim('not found'));
+  printLine('Version', agentBrowserVersion || chalk.dim('not available'));
+  console.log('');
+
+  console.log(statusLabel(Boolean(ffmpegPath), 'ffmpeg'));
+  printLine('Path', ffmpegPath || chalk.dim('not found'));
+  printLine('Version', ffmpegVersion || chalk.dim('not available'));
+  console.log('');
+
+  console.log(statusLabel(Boolean(session), 'active session'));
+  if (session) {
+    printLine('Session dir', session.sessionDir);
+    printLine('Recording', session.recordingActive ? 'active' : 'stopped');
+    printLine('Port', String(session.port));
+  } else {
+    printLine('Session dir', chalk.dim('none'));
+  }
+}

--- a/src/utils/process.test.ts
+++ b/src/utils/process.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { getShellExecutable, parseWindowsNetstatOutput } from './process.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  findExecutablePath,
+  getShellExecutable,
+  parseWindowsNetstatOutput,
+  readCommandVersion,
+} from './process.js';
 
 describe('getShellExecutable', () => {
   it('uses cmd.exe on Windows when ComSpec is missing', () => {
@@ -29,5 +34,31 @@ TCP    [::]:3000              [::]:0                 LISTENING       5678
 `;
 
     expect(parseWindowsNetstatOutput(output, 3000)).toEqual([1234, 5678]);
+  });
+});
+
+describe('findExecutablePath', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses command -v on Unix-like platforms', () => {
+    const execSpy = vi.fn().mockReturnValue('/usr/local/bin/ffmpeg\n');
+
+    expect(findExecutablePath('ffmpeg', 'darwin', execSpy as never)).toBe('/usr/local/bin/ffmpeg');
+    expect(execSpy).toHaveBeenCalledWith('command -v ffmpeg', expect.any(Object));
+  });
+});
+
+describe('readCommandVersion', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the first output line from the version command', () => {
+    const execSpy = vi.fn().mockReturnValue('ffmpeg version 7.0\nbuilt with clang\n');
+
+    expect(readCommandVersion('ffmpeg', ['--version'], execSpy as never)).toBe('ffmpeg version 7.0');
+    expect(execSpy).toHaveBeenCalledWith('ffmpeg --version', expect.any(Object));
   });
 });

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,5 +1,7 @@
 import { execSync, spawn, type ChildProcess, type SpawnOptions } from 'child_process';
 
+type ExecSyncLike = typeof execSync;
+
 export function getShellExecutable(
   platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
@@ -93,4 +95,37 @@ export function terminateProcessTree(pid: number): void {
   }
 
   process.kill(-pid, 'SIGKILL');
+}
+
+export function findExecutablePath(
+  command: string,
+  platform = process.platform,
+  execFn: ExecSyncLike = execSync,
+): string | null {
+  try {
+    const lookupCommand = platform === 'win32' ? `where ${command}` : `command -v ${command}`;
+    const output = execFn(lookupCommand, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return output.split(/\r?\n/)[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+export function readCommandVersion(
+  command: string,
+  args: string[] = ['--version'],
+  execFn: ExecSyncLike = execSync,
+): string | null {
+  try {
+    const output = execFn([command, ...args].join(' '), {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return output.split(/\r?\n/)[0] || null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- add `proofshot doctor` to inspect the local ProofShot environment
- report config path, output directory, browser mode, viewport, installed binaries, and any active session
- add focused tests for the new command and command lookup helpers
- document the diagnostic workflow in the user-facing docs

## Problem
When ProofShot setup is wrong, the first failure often happens later in the workflow during start, screenshot capture, or PR upload.

A dedicated diagnostic command gives users and maintainers a fast way to inspect the local environment before starting a verification run.

## Solution
This change adds a `proofshot doctor` command that prints the current ProofShot environment, including config path, browser mode, viewport, installed binaries, and any active session state.

## Testing
- `npm test`
- `npm run build`
